### PR TITLE
add CNAME, move .nojekyll to vuepress public dir

### DIFF
--- a/docs/.vuepress/public/CNAME
+++ b/docs/.vuepress/public/CNAME
@@ -1,0 +1,2 @@
+pulsar-edit.dev
+www.pulsar-edit.dev


### PR DESCRIPTION
Adds CNAME and .nojekyll to [vuepress public directory](https://v2.vuepress.vuejs.org/guide/assets.html#public-files), so that it is included in the site build output and not overwritten on deploy.