### PR TITLE
Add Debian/Ubuntu build instructions

### DIFF
--- a/docs/docs/launch-manual/sections/core-hacking/sections/building-pulsar.md
+++ b/docs/docs/launch-manual/sections/core-hacking/sections/building-pulsar.md
@@ -27,7 +27,14 @@ For OS or distribution specific instructions see below:
 #### Ubuntu/Debian
 
 ```sh
-TODO: Ubuntu instructions
+# Install development packages
+
+apt install build-essential libxkbfile-dev libsecret-1-dev libx11-dev
+
+# Install Node16 (using `nvm` - see above) and enable corepack (for `yarn`)
+
+nvm install 16
+corepack enable
 ```
 
 #### Fedora/RHEL


### PR DESCRIPTION
Add Debian build instructions.
Performed on a basic Debian 11 VM: 

```
OS: Debian GNU/Linux 11 (bullseye) x86_64 
Kernel: 5.10.0-18-amd64
```
