### PR TITLE
Add ch2 archive includes

### DIFF
--- a/docs/docs/atom-archive/using-atom/index.md
+++ b/docs/docs/atom-archive/using-atom/index.md
@@ -2,8 +2,32 @@
 title: "Chapter 2 : Using Atom"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom
+documentation. As this may no longer be relevant to Pulsar, you use this at
+your own risk. Current Pulsar documentation for this section is found at the
+[documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## Using Atom
 
 Now that we've covered the very basics of Atom, we are ready to see how to really start getting the most out of using it. In this chapter we'll look at how to find and install new packages in order to add new functionality, how to find and install new themes, how to work with and manipulate text in a more advanced way, how to customize the editor in any way you wish, how to work with Git for version control and more.
 
 At the end of this chapter, you should have a customized environment that you're comfortable in and you should be able to change, create and move through your text like a master.
+
+@include(./sections/atom-packages.md)
+@include(./sections/moving-in-atom.md)
+@include(./sections/atom-selections.md)
+@include(./sections/editing-and-deleting-text.md)
+@include(./sections/find-and-replace.md)
+@include(./sections/snippets.md)
+@include(./sections/autocomplete.md)
+@include(./sections/folding.md)
+@include(./sections/panes.md)
+@include(./sections/pending-pane-items.md)
+@include(./sections/grammar.md)
+@include(./sections/version-control-in-atom.md)
+@include(./sections/github-package.md)
+@include(./sections/writing-in-atom.md)
+@include(./sections/basic-customization.md)
+@include(./sections/summary.md)

--- a/docs/docs/atom-archive/using-atom/sections/atom-packages.md
+++ b/docs/docs/atom-archive/using-atom/sections/atom-packages.md
@@ -1,7 +1,3 @@
----
-title: Atom Packages
----
-
 ### Atom Packages
 
 First we'll start with the Atom package system. As we mentioned previously, Atom itself is a very basic core of functionality that ships with a number of useful packages that add new features like the [Tree View](https://github.com/atom/tree-view) and the [Settings View](https://github.com/atom/settings-view).

--- a/docs/docs/atom-archive/using-atom/sections/atom-selections.md
+++ b/docs/docs/atom-archive/using-atom/sections/atom-selections.md
@@ -1,7 +1,3 @@
----
-title: Atom Selections
----
-
 ### Atom Selections
 
 Text selections in Atom support a number of actions, such as scoping deletion, indentation and search actions, and marking text for actions such as quoting and bracketing.

--- a/docs/docs/atom-archive/using-atom/sections/autocomplete.md
+++ b/docs/docs/atom-archive/using-atom/sections/autocomplete.md
@@ -1,7 +1,3 @@
----
-title: Autocomplete
----
-
 ### Autocomplete
 
 If you're still looking to save some typing time, Atom also ships with simple autocompletion functionality.

--- a/docs/docs/atom-archive/using-atom/sections/basic-customization.md
+++ b/docs/docs/atom-archive/using-atom/sections/basic-customization.md
@@ -1,7 +1,3 @@
----
-title: Basic Customization
----
-
 ### Basic Customization
 
 Now that we are feeling comfortable with just about everything built into Atom, let's look at how to tweak it. Perhaps there is a keybinding that you use a lot but feels wrong or a color that isn't quite right for you. Atom is amazingly flexible, so let's go over some of the simpler flexes it can do.

--- a/docs/docs/atom-archive/using-atom/sections/editing-and-deleting-text.md
+++ b/docs/docs/atom-archive/using-atom/sections/editing-and-deleting-text.md
@@ -1,7 +1,3 @@
----
-title: Editing and Deleting Text
----
-
 ### Editing and Deleting Text
 
 So far we've looked at a number of ways to move around and select regions of a file, so now let's actually change some of that text. Obviously you can type in order to insert characters, but there are also a number of ways to delete and manipulate text that could come in handy.

--- a/docs/docs/atom-archive/using-atom/sections/find-and-replace.md
+++ b/docs/docs/atom-archive/using-atom/sections/find-and-replace.md
@@ -1,7 +1,3 @@
----
-title: Find and Replace
----
-
 ### Find and Replace
 
 Finding and replacing text in your file or project is quick and easy in Atom.

--- a/docs/docs/atom-archive/using-atom/sections/folding.md
+++ b/docs/docs/atom-archive/using-atom/sections/folding.md
@@ -1,7 +1,3 @@
----
-title: Folding
----
-
 ### Folding
 
 If you want to see an overview of the structure of the code file you're working on, folding can be a helpful tool. Folding hides blocks of code such as functions or looping blocks in order to simplify what is on your screen.

--- a/docs/docs/atom-archive/using-atom/sections/github-package.md
+++ b/docs/docs/atom-archive/using-atom/sections/github-package.md
@@ -1,7 +1,3 @@
----
-title: GitHub package
----
-
 ### GitHub package
 
 The github package brings Git and GitHub integration right inside Atom.

--- a/docs/docs/atom-archive/using-atom/sections/grammar.md
+++ b/docs/docs/atom-archive/using-atom/sections/grammar.md
@@ -1,7 +1,3 @@
----
-title: Grammar
----
-
 ### Grammar
 
 The "grammar" of a file is what language Atom has associated with that file. Types of grammars would include "Java" or "GitHub-Flavored Markdown". We looked at this a bit when we created some snippets in [Snippets](/using-atom/sections/snippets/).

--- a/docs/docs/atom-archive/using-atom/sections/moving-in-atom.md
+++ b/docs/docs/atom-archive/using-atom/sections/moving-in-atom.md
@@ -1,7 +1,3 @@
----
-title: Moving in Atom
----
-
 ### Moving in Atom
 
 While it's pretty easy to move around Atom by clicking with the mouse or using the arrow keys, there are some keybindings that may help you keep your hands on the keyboard and navigate around a little faster.

--- a/docs/docs/atom-archive/using-atom/sections/panes.md
+++ b/docs/docs/atom-archive/using-atom/sections/panes.md
@@ -1,7 +1,3 @@
----
-title: Panes
----
-
 ### Panes
 
 You can split any editor pane horizontally or vertically by using <kbd class="platform-mac">Cmd+K</kbd><kbd class="platform-windows platform-linux">Ctrl+K</kbd> <kbd class="platform-all">Up/Down/Left/Right</kbd> where the direction key is the direction to split the pane. Once you have a split pane, you can switch between them with <kbd class="platform-mac">Cmd+K</kbd><kbd class="platform-windows platform-linux">Ctrl+K</kbd> <kbd class="platform-mac">Cmd+Up/Down/Left/Right</kbd><kbd class="platform-windows platform-linux">Ctrl+Up/Down/Left/Right</kbd> where the direction is the direction the focus should move to.

--- a/docs/docs/atom-archive/using-atom/sections/pending-pane-items.md
+++ b/docs/docs/atom-archive/using-atom/sections/pending-pane-items.md
@@ -1,7 +1,3 @@
----
-title: Pending Pane Items
----
-
 ### Pending Pane Items
 
 _"Pending Pane Items" were formerly referred to as "Preview Tabs"_

--- a/docs/docs/atom-archive/using-atom/sections/snippets.md
+++ b/docs/docs/atom-archive/using-atom/sections/snippets.md
@@ -1,7 +1,3 @@
----
-title: Snippets
----
-
 ### Snippets
 
 Snippets are an incredibly powerful way to quickly generate commonly needed code syntax from a shortcut.

--- a/docs/docs/atom-archive/using-atom/sections/summary.md
+++ b/docs/docs/atom-archive/using-atom/sections/summary.md
@@ -1,7 +1,3 @@
----
-title: Summary
----
-
 ### Summary
 
 At this point you should be something of an Atom master user. You should be able to navigate and manipulate your text and files like a wizard. You should also be able to customize Atom backwards and forwards to make it look and act just how you want it to.

--- a/docs/docs/atom-archive/using-atom/sections/version-control-in-atom.md
+++ b/docs/docs/atom-archive/using-atom/sections/version-control-in-atom.md
@@ -1,7 +1,3 @@
----
-title: Version Control in Atom
----
-
 ### Version Control in Atom
 
 Version control is an important aspect of any project and Atom comes with basic [Git](https://git-scm.com) and [GitHub](https://github.com) integration built in.

--- a/docs/docs/atom-archive/using-atom/sections/writing-in-atom.md
+++ b/docs/docs/atom-archive/using-atom/sections/writing-in-atom.md
@@ -1,7 +1,3 @@
----
-title: Writing in Atom
----
-
 ### Writing in Atom
 
 Though it is probably most common to use Atom to write software code, Atom can also be used to write prose quite effectively. Most often this is done in some sort of markup language such as Asciidoc or [Markdown](https://help.github.com/articles/about-writing-and-formatting-on-github/) (in which this manual is written). Here we'll quickly cover a few of the tools Atom provides for helping you write prose.


### PR DESCRIPTION
Actual content of ch2 was not present on website as not included in the index file.
This adds the includes and removes the yaml frontmatter from the head of each `sections/*.md` file.
Also the `danger` tag has been added under the chapter header of the index.