### PR TITLE
Add fontawesome to the theme

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -27,6 +27,7 @@ export default defineUserConfig({
   theme: hopeTheme({
     displayAllHeaders: true,
     editLinks: true,
+    iconAssets: "fontawesome",
     navbar: navbar_en,
     locales: {
       "/": {


### PR DESCRIPTION
Adds FA to the theme so it can be addressed by the HTML.

e.g. `<i class="fa-solid fa-user"></i>` will now display the icon.