### PR TITLE
Add includes to Appendix B: FAQ

### DIFF
--- a/docs/docs/atom-archive/faq/index.md
+++ b/docs/docs/atom-archive/faq/index.md
@@ -2,6 +2,41 @@
 title: "Appendix B : FAQ"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom documentation. As this may no longer be relevant to Pulsar, use this at your own risk.
+Current Pulsar documentation is found at [documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## FAQ
 
 The collection of Frequently Asked Questions about Atom.
+
+@include(./sections/is-atom-open-source.md)
+@include(./sections/what-does-atom-cost.md)
+@include(./sections/what-platforms-does-atom-run-on.md)
+@include(./sections/how-can-i-contribute-to-atom.md)
+@include(./sections/why-does-atom-collect-usage-data.md)
+@include(./sections/atom-in-the-cloud.md)
+@include(./sections/what-s-the-difference-between-an-ide-and-an-editor.md)
+@include(./sections/how-can-i-tell-if-subpixel-antialiasing-is-working.md)
+@include(./sections/why-is-atom-deleting-trailing-whitespace-why-is-there-a-newline-at-the-end-of-the-file.md)
+@include(./sections/what-does-safe-mode-do.md)
+@include(./sections/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it.md)
+@include(./sections/i-m-using-an-international-keyboard-and-keys-that-use-altgr-or-ctrl-alt-aren-t-working.md)
+@include(./sections/i-m-having-a-problem-with-julia-what-do-i-do.md)
+@include(./sections/i-m-getting-an-error-about-a-self-signed-certificate-what-do-i-do.md)
+@include(./sections/i-m-having-a-problem-with-platformio-what-do-i-do.md)
+@include(./sections/how-do-i-make-atom-recognize-a-file-with-extension-x-as-language-y.md)
+@include(./sections/how-do-i-make-the-welcome-screen-stop-showing-up.md)
+@include(./sections/how-do-i-preview-web-page-changes-automatically.md)
+@include(./sections/how-do-i-accept-input-from-my-program-or-script-when-using-the-script-package.md)
+@include(./sections/i-am-unable-to-update-to-the-latest-version-of-atom-on-macos-how-do-i-fix-this.md)
+@include(./sections/i-m-trying-to-change-my-syntax-colors-from-styles-less-but-it-isn-t-working.md)
+@include(./sections/how-do-i-build-or-execute-code-i-ve-written-in-atom.md)
+@include(./sections/how-do-i-uninstall-atom-on-macos.md)
+@include(./sections/macos-mojave-font-rendering-change.md)
+@include(./sections/why-does-macos-say-that-atom-wants-to-access-my-calendar-contacts-photos-etc.md)
+@include(./sections/how-do-i-turn-on-line-wrap.md)
+@include(./sections/the-menu-bar-disappeared-how-do-i-get-it-back.md)
+@include(./sections/how-do-i-use-a-newline-in-the-result-of-find-and-replace.md)
+@include(./sections/what-is-this-line-on-the-right-in-the-editor-view.md)

--- a/docs/docs/atom-archive/faq/sections/atom-in-the-cloud.md
+++ b/docs/docs/atom-archive/faq/sections/atom-in-the-cloud.md
@@ -1,7 +1,3 @@
----
-title: Atom in the cloud?
----
-
 ### Atom in the cloud?
 
 The Atom team has no plans to make a cloud- or server-based version of Atom. For discussion of the idea, see the [Atom message board](https://github.com/atom/atom/discussions).

--- a/docs/docs/atom-archive/faq/sections/how-can-i-contribute-to-atom.md
+++ b/docs/docs/atom-archive/faq/sections/how-can-i-contribute-to-atom.md
@@ -1,7 +1,3 @@
----
-title: How can I contribute to Atom?
----
-
 ### How can I contribute to Atom?
 
 You can contribute by [creating a package](https://flight-manual.atom.io/hacking-atom/sections/tools-of-the-trade/) that adds something awesome to Atom!

--- a/docs/docs/atom-archive/faq/sections/how-can-i-tell-if-subpixel-antialiasing-is-working.md
+++ b/docs/docs/atom-archive/faq/sections/how-can-i-tell-if-subpixel-antialiasing-is-working.md
@@ -1,7 +1,3 @@
----
-title: How can I tell if subpixel antialiasing is working?
----
-
 ### How can I tell if subpixel antialiasing is working?
 
 If you take a screenshot and blow it up you'll see something like this:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-accept-input-from-my-program-or-script-when-using-the-script-package.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-accept-input-from-my-program-or-script-when-using-the-script-package.md
@@ -1,7 +1,3 @@
----
-title: How do I accept input from my program or script when using the script package?
----
-
 ### How do I accept input from my program or script when using the script package?
 
 The [script package](https://atom.io/packages/script) doesn't support accepting input from the user in the scripts it runs. The option with the best chance of success is to run the script or program from the terminal that comes with your operating system. If that isn't something you want to do, you could try one of the many [terminal packages](https://atom.io/packages/search?q=terminal) that are available.

--- a/docs/docs/atom-archive/faq/sections/how-do-i-build-or-execute-code-i-ve-written-in-atom.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-build-or-execute-code-i-ve-written-in-atom.md
@@ -1,7 +1,3 @@
----
-title: How do I build or execute code I've written in Atom?
----
-
 ### How do I build or execute code I've written in Atom?
 
 Atom doesn't have built-in support for building any type of code nor does it have built-in support for executing any kind of code other than JavaScript. Atom has a JavaScript interactive command-line (also known as a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)) available through the Developer Tools. You can access the JavaScript REPL by using the following steps:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-make-atom-recognize-a-file-with-extension-x-as-language-y.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-make-atom-recognize-a-file-with-extension-x-as-language-y.md
@@ -1,7 +1,3 @@
----
-title: How do I make Atom recognize a file with extension X as language Y?
----
-
 ### How do I make Atom recognize a file with extension X as language Y?
 
 Atom includes a feature called "custom file types" which you can use by adding some entries into your `config.cson` that look like this:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-make-the-welcome-screen-stop-showing-up.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-make-the-welcome-screen-stop-showing-up.md
@@ -1,7 +1,3 @@
----
-title: How do I make the Welcome screen stop showing up?
----
-
 ### How do I make the Welcome screen stop showing up?
 
 You can make the Welcome screen stop showing up by unchecking this box in the welcome screen itself:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-preview-web-page-changes-automatically.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-preview-web-page-changes-automatically.md
@@ -1,7 +1,3 @@
----
-title: How do I preview web page changes automatically?
----
-
 ### How do I preview web page changes automatically?
 
 There are a couple different approaches, for example:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-turn-on-line-wrap.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-turn-on-line-wrap.md
@@ -1,7 +1,3 @@
----
-title: How do I turn on line wrap?
----
-
 ### How do I turn on line wrap?
 
 1. Open the Settings View using <kbd>Cmd+,</kbd> on macOS or <kbd>Ctrl+,</kbd> on other platforms

--- a/docs/docs/atom-archive/faq/sections/how-do-i-uninstall-atom-on-macos.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-uninstall-atom-on-macos.md
@@ -1,7 +1,3 @@
----
-title: How do I uninstall Atom on macOS?
----
-
 ### How do I uninstall Atom on macOS?
 
 To uninstall Atom on macOS, run the following commands from the command line:

--- a/docs/docs/atom-archive/faq/sections/how-do-i-use-a-newline-in-the-result-of-find-and-replace.md
+++ b/docs/docs/atom-archive/faq/sections/how-do-i-use-a-newline-in-the-result-of-find-and-replace.md
@@ -1,7 +1,3 @@
----
-title: How do I use a newline in the result of find and replace?
----
-
 ### How do I use a newline in the result of find and replace?
 
 To use a newline in the result of find and replace, enable the `Use Regex` option and use "\n" in your replacement text. For example, given this text:

--- a/docs/docs/atom-archive/faq/sections/i-am-unable-to-update-to-the-latest-version-of-atom-on-macos-how-do-i-fix-this.md
+++ b/docs/docs/atom-archive/faq/sections/i-am-unable-to-update-to-the-latest-version-of-atom-on-macos-how-do-i-fix-this.md
@@ -1,7 +1,3 @@
----
-title: I am unable to update to the latest version of Atom on macOS. How do I fix this?
----
-
 ### I am unable to update to the latest version of Atom on macOS. How do I fix this?
 
 Atom shows there is a new version available but the version fails to install. You might have an error message showing a permissions error for example:

--- a/docs/docs/atom-archive/faq/sections/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it.md
+++ b/docs/docs/atom-archive/faq/sections/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it.md
@@ -1,7 +1,3 @@
----
-title: I have a question about a specific Atom community package. Where is the best place to ask it?
----
-
 ### I have a question about a specific Atom community package. Where is the best place to ask it?
 
 The best place to get a question answered quickly is probably the Issues list for that specific package. You can find the Issues list for a package by going to that package's page on https://atom.io and clicking the Bugs button:

--- a/docs/docs/atom-archive/faq/sections/i-m-getting-an-error-about-a-self-signed-certificate-what-do-i-do.md
+++ b/docs/docs/atom-archive/faq/sections/i-m-getting-an-error-about-a-self-signed-certificate-what-do-i-do.md
@@ -1,7 +1,3 @@
----
-title: I’m getting an error about a “self-signed certificate”. What do I do?
----
-
 ### I’m getting an error about a “self-signed certificate”. What do I do?
 
 This means that there is a proxy between you and our servers where someone (typically your employer) has installed a "self-signed" security certificate in the proxy. A self-signed certificate is one that isn't trusted by anyone but the person who created the certificate. Most security certificates are backed by known, trusted and certified companies. So Atom is warning you that your connection to our servers can be snooped and even hacked by whoever created the self-signed certificate. Since it is self-signed, Atom has no way of knowing who that is.

--- a/docs/docs/atom-archive/faq/sections/i-m-having-a-problem-with-julia-what-do-i-do.md
+++ b/docs/docs/atom-archive/faq/sections/i-m-having-a-problem-with-julia-what-do-i-do.md
@@ -1,7 +1,3 @@
----
-title: I’m having a problem with Julia! What do I do?
----
-
 ### I’m having a problem with Julia! What do I do?
 
 [Juno](http://junolab.org/) is a development environment built on top of Atom but has enough separate customizations that they have their own [message board](https://discourse.julialang.org/c/tools/juno). You will probably have better luck asking your question there.

--- a/docs/docs/atom-archive/faq/sections/i-m-having-a-problem-with-platformio-what-do-i-do.md
+++ b/docs/docs/atom-archive/faq/sections/i-m-having-a-problem-with-platformio-what-do-i-do.md
@@ -1,7 +1,3 @@
----
-title: I’m having a problem with PlatformIO! What do I do?
----
-
 ### I’m having a problem with PlatformIO! What do I do?
 
 [PlatformIO](http://platformio.org/) is a development environment built on top of Atom but has enough separate customizations that they have their own [message board](https://community.platformio.org/). If your question has to do with PlatformIO specifically, you may have better luck getting your answer there.

--- a/docs/docs/atom-archive/faq/sections/i-m-trying-to-change-my-syntax-colors-from-styles-less-but-it-isn-t-working.md
+++ b/docs/docs/atom-archive/faq/sections/i-m-trying-to-change-my-syntax-colors-from-styles-less-but-it-isn-t-working.md
@@ -1,7 +1,3 @@
----
-title: I’m trying to change my syntax colors from styles.less, but it isn’t working!
----
-
 ### I’m trying to change my syntax colors from styles.less, but it isn’t working!
 
 The best way to tweak the syntax is to wrap your syntax style rules with `atom-text-editor` and then prepend every scope with `syntax--`. If you want your comments to be blue, for example, you would do the following:

--- a/docs/docs/atom-archive/faq/sections/i-m-using-an-international-keyboard-and-keys-that-use-altgr-or-ctrl-alt-aren-t-working.md
+++ b/docs/docs/atom-archive/faq/sections/i-m-using-an-international-keyboard-and-keys-that-use-altgr-or-ctrl-alt-aren-t-working.md
@@ -1,7 +1,3 @@
----
-title: I’m using an international keyboard and keys that use AltGr or Ctrl+Alt aren’t working
----
-
 ### I’m using an international keyboard and keys that use AltGr or Ctrl+Alt aren’t working
 
 As of Atom v1.12, a fix is available for this. See [the blog post "The Wonderful World of Keyboards"](http://blog.atom.io/2016/10/17/the-wonderful-world-of-keyboards.html) for more information.

--- a/docs/docs/atom-archive/faq/sections/is-atom-open-source.md
+++ b/docs/docs/atom-archive/faq/sections/is-atom-open-source.md
@@ -1,7 +1,3 @@
----
-title: Is Atom open source?
----
-
 ### Is Atom open source?
 
 Yes, [Atom is licensed under the MIT license.](https://github.com/atom/atom/blob/master/LICENSE.md)

--- a/docs/docs/atom-archive/faq/sections/macos-mojave-font-rendering-change.md
+++ b/docs/docs/atom-archive/faq/sections/macos-mojave-font-rendering-change.md
@@ -1,7 +1,3 @@
----
-title: MacOS Mojave font rendering change
----
-
 ### MacOS Mojave font rendering change
 
 In [macOS Mojave v10.14.x](https://www.apple.com/macos/mojave/), Apple disabled subpixel antialiasing on all monitors by default. Previous to Mojave, subpixel antialiasing was disabled only on Retina displays or on all displays if the "LCD font smoothing" option was disabled in System Preferences. With this change in Mojave, some users have reported that [their fonts in Atom appear "thinner" or "dimmer" than they did previously.](https://github.com/atom/atom/issues/17486) It can look better or worse depending on your font and theme selections, but in all cases this is completely a side-effect of the change that Apple made to their font rendering and is outside Atom's and Electron's control.

--- a/docs/docs/atom-archive/faq/sections/the-menu-bar-disappeared-how-do-i-get-it-back.md
+++ b/docs/docs/atom-archive/faq/sections/the-menu-bar-disappeared-how-do-i-get-it-back.md
@@ -1,7 +1,3 @@
----
-title: The menu bar disappeared, how do I get it back?
----
-
 ### The menu bar disappeared, how do I get it back?
 
 If you're running Windows or Linux and you don't see the menu bar, it may have been accidentally toggled it off. You can bring it back from the Command Palette with `Window: Toggle Menu Bar` or by pressing <kbd>Alt</kbd>.

--- a/docs/docs/atom-archive/faq/sections/what-does-atom-cost.md
+++ b/docs/docs/atom-archive/faq/sections/what-does-atom-cost.md
@@ -1,7 +1,3 @@
----
-title: What does Atom cost?
----
-
 ### What does Atom cost?
 
 Since the 6<sup>th</sup> of May, 2014, [Atom has been available for download free of charge for everyone](https://github.blog/2014-05-06-atom-free-and-open-source-for-everyone/). This includes business and enterprise use.

--- a/docs/docs/atom-archive/faq/sections/what-does-safe-mode-do.md
+++ b/docs/docs/atom-archive/faq/sections/what-does-safe-mode-do.md
@@ -1,7 +1,3 @@
----
-title: What does Safe Mode do?
----
-
 ### What does Safe Mode do?
 
 Atom's Safe Mode, which can be activated by completely exiting all instances of Atom and launching it again using the command `atom --safe` from the command line, does the following:

--- a/docs/docs/atom-archive/faq/sections/what-is-this-line-on-the-right-in-the-editor-view.md
+++ b/docs/docs/atom-archive/faq/sections/what-is-this-line-on-the-right-in-the-editor-view.md
@@ -1,7 +1,3 @@
----
-title: What is this line on the right in the editor view?
----
-
 ### What is this line on the right in the editor view?
 
 ![Wrap guide line](@images/atom/wrap-guide-line.png)

--- a/docs/docs/atom-archive/faq/sections/what-platforms-does-atom-run-on.md
+++ b/docs/docs/atom-archive/faq/sections/what-platforms-does-atom-run-on.md
@@ -1,7 +1,3 @@
----
-title: What platforms does Atom run on?
----
-
 ### What platforms does Atom run on?
 
 Prebuilt versions of Atom are available for OS X 10.10 or later, Windows 7 or later, RedHat Linux, and Ubuntu Linux.

--- a/docs/docs/atom-archive/faq/sections/what-s-the-difference-between-an-ide-and-an-editor.md
+++ b/docs/docs/atom-archive/faq/sections/what-s-the-difference-between-an-ide-and-an-editor.md
@@ -1,7 +1,3 @@
----
-title: What's the difference between an IDE and an editor?
----
-
 ### What's the difference between an IDE and an editor?
 
 The term "IDE" comes from **I**ntegrated **D**evelopment **E**nvironment. It is intended as a set of tools that all work together: text editor, compiler, build or make integration, debugging, etc. Virtually all IDEs are tied specifically to a language or framework or tightly collected set of languages or frameworks. Some examples: Visual Studio for .NET and other Microsoft languages, RubyMine for Ruby, IntelliJ for Java, XCode for Apple technologies.

--- a/docs/docs/atom-archive/faq/sections/why-does-atom-collect-usage-data.md
+++ b/docs/docs/atom-archive/faq/sections/why-does-atom-collect-usage-data.md
@@ -1,7 +1,3 @@
----
-title: Why does Atom collect usage data?
----
-
 ### Why does Atom collect usage data?
 
 In the same way that aggregate usage information is important when developing a web application, we've found that it's just as important for desktop applications. By knowing which Atom features are being used the most, and how the editor is performing, we can focus our development efforts in the right place. For details on what data Atom is sending or to learn how to disable metrics gathering, visit https://github.com/atom/metrics.

--- a/docs/docs/atom-archive/faq/sections/why-does-macos-say-that-atom-wants-to-access-my-calendar-contacts-photos-etc.md
+++ b/docs/docs/atom-archive/faq/sections/why-does-macos-say-that-atom-wants-to-access-my-calendar-contacts-photos-etc.md
@@ -1,7 +1,3 @@
----
-title: Why does macOS say that Atom wants to access my calendar, contacts, photos, etc.?
----
-
 ### Why does macOS say that Atom wants to access my calendar, contacts, photos, etc.?
 
 With macOS 10.14 Mojave, Apple introduced new privacy protections similar to the existing protections found in iOS. Whenever an application attempts to access the files inside certain newly-protected directories, macOS asks the user whether they want to allow the application to access the content in those directories. These new privacy protections apply to the directories that contain your calendars, contacts, photos, mail, messages, and Time Machine backups.

--- a/docs/docs/atom-archive/faq/sections/why-is-atom-deleting-trailing-whitespace-why-is-there-a-newline-at-the-end-of-the-file.md
+++ b/docs/docs/atom-archive/faq/sections/why-is-atom-deleting-trailing-whitespace-why-is-there-a-newline-at-the-end-of-the-file.md
@@ -1,7 +1,3 @@
----
-title: Why is Atom deleting trailing whitespace? Why is there a newline at the end of the file?
----
-
 ### Why is Atom deleting trailing whitespace? Why is there a newline at the end of the file?
 
 Atom ships with the [`whitespace` package][1], which by default strips trailing whitespace from lines in your file, and inserts a final trailing newline to indicate end-of-file [as per the POSIX standard][2].


### PR DESCRIPTION
Adds the FAQ pages to the index so they can display.
Added the `STOP` block to the start of the index page.
Removed YAML titles from section pages
No edits made to any FAQ content.