### PR TITLE
Add includes to Appendix C: Shadow DOM

### DIFF
--- a/docs/docs/atom-archive/shadow-dom/index.md
+++ b/docs/docs/atom-archive/shadow-dom/index.md
@@ -5,3 +5,5 @@ title: "Appendix C : Shadow DOM"
 ## Shadow DOM
 
 In Atom `1.13` the Shadow DOM got removed from text editors. Find a guide how to migrate your theme or package in this appendix.
+
+@include(./sections/removing-shadow-dom-styles.md)

--- a/docs/docs/atom-archive/shadow-dom/index.md
+++ b/docs/docs/atom-archive/shadow-dom/index.md
@@ -2,6 +2,11 @@
 title: "Appendix C : Shadow DOM"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom documentation. As this may no longer be relevant to Pulsar, use this at your own risk.
+Current Pulsar documentation is found at [documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## Shadow DOM
 
 In Atom `1.13` the Shadow DOM got removed from text editors. Find a guide how to migrate your theme or package in this appendix.

--- a/docs/docs/atom-archive/shadow-dom/sections/removing-shadow-dom-styles.md
+++ b/docs/docs/atom-archive/shadow-dom/sections/removing-shadow-dom-styles.md
@@ -1,7 +1,3 @@
----
-title: Removing Shadow DOM styles
----
-
 ### Removing Shadow DOM styles
 
 In Atom `1.13` the Shadow DOM got removed from text editors. For more background on the reasoning, check out the [Pull Request](https://github.com/atom/atom/pull/12903) where it was removed. In this guide you will learn how to migrate your theme or package.


### PR DESCRIPTION
Include was missing from index so has been added for the only file (removing-shadow-dom-styles.md).

YAML removed from section file.

Added STOP block to index.