### PR TITLE
Fix link to core-hacking

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,5 +9,5 @@ description: Home for Pulsar's Documentation
 The developers and community around the Pulsar Editor would like to give you a
 warm welcome to our Documentation home. Here you can find any information you
 need from our [Getting Started](/docs/launch-manual/sections/getting-started) section to
-sections on [Hacking the Core](#) (the possibilities for utilizing the
+sections on [Hacking the Core](/docs/launch-manual/sections/core-hacking) (the possibilities for utilizing the
 functionality of Pulsar to it's fullest) to even our [API](#).


### PR DESCRIPTION
Fixes link on front page to link to the core-hacking index.