### PR TITLE
General website improvements - links, about us & community

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -28,7 +28,7 @@ export default defineUserConfig({
     displayAllHeaders: true,
     editLinks: true,
     iconAssets: "fontawesome",
-    repo: "pulsar-edit/pulsar",
+    repo: "pulsar-edit",
     repoLabel: "GitHub",
     navbar: navbar_en,
     locales: {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -28,6 +28,8 @@ export default defineUserConfig({
     displayAllHeaders: true,
     editLinks: true,
     iconAssets: "fontawesome",
+    repo: "pulsar-edit/pulsar",
+    repoLabel: "GitHub",
     navbar: navbar_en,
     locales: {
       "/": {

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -1,6 +1,7 @@
 const navbar_en = [
   {
     text: "Start Here",
+    icon: 'solid fa-flag',
     children: [
       '/docs/launch-manual',
       '/docs/packages/core',
@@ -9,14 +10,17 @@ const navbar_en = [
   },
   {
     text: 'Docs',
+    icon: 'solid fa-file-lines',
     link: '/docs/'
   },
   {
     text: "About Us",
+    icon: 'solid fa-sun',
     link: "/about/"
   },
   {
     text: "Community",
+    icon: 'solid fa-user-group',
     children: [
       {
         text: "Community areas",
@@ -44,6 +48,11 @@ const navbar_en = [
         link: "https://opencollective.com/pulsar-edit"
       }
     ]
+  },
+  {
+    text: "Packages",
+    icon: 'solid fa-box-open',
+    link: "https://web.pulsar-edit.dev/"
   }
 ];
 

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -28,14 +28,14 @@ const navbar_en = [
         link: "/community/"
       },
       {
-        text: "Discord",
-        icon: 'brands fa-discord',
-        link: "https://discord.gg/7aEbB9dGRT"
-      },
-      {
         text: "Discussions",
         icon: 'solid fa-comments',
         link: "https://github.com/orgs/pulsar-edit/discussions"
+      },
+      {
+        text: "Discord",
+        icon: 'brands fa-discord',
+        link: "https://discord.gg/7aEbB9dGRT"
       },
       {
         text: "Reddit",

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -14,6 +14,11 @@ const navbar_en = [
     link: '/docs/'
   },
   {
+    text: 'Repositories',
+    icon: 'brands fa-github',
+    link: '/repos/'
+  },
+  {
     text: "About Us",
     icon: 'solid fa-sun',
     link: "/about/"

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -16,8 +16,34 @@ const navbar_en = [
     link: "/about/"
   },
   {
-    text: "Discord",
-    link: "https://discord.gg/7aEbB9dGRT"
+    text: "Community",
+    children: [
+      {
+        text: "Community areas",
+        icon: 'solid fa-house',
+        link: "/community/"
+      },
+      {
+        text: "Discord",
+        icon: 'brands fa-discord',
+        link: "https://discord.gg/7aEbB9dGRT"
+      },
+      {
+        text: "Discussions",
+        icon: 'solid fa-comments',
+        link: "https://github.com/orgs/pulsar-edit/discussions"
+      },
+      {
+        text: "Reddit",
+        icon: 'brands fa-reddit',
+        link: "https://www.reddit.com/r/pulsaredit/"
+      },
+      {
+        text: "OpenCollective",
+        icon: 'solid fa-hand-holding-dollar',
+        link: "https://opencollective.com/pulsar-edit"
+      }
+    ]
   }
 ];
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,3 +4,32 @@ path: /about/
 ---
 
 # About us
+
+## The team
+
+The team behind Pulsar is a community that came about naturally after the
+announcement of [Atom's Sunset](https://github.blog/2022-06-08-sunsetting-atom/)
+and decided that they needed to do something about it to keep their favorite
+editor alive.
+
+This is a true community-led project to modernize, update and improve the
+original Atom project into a contemporary, hackable and fully open editor.
+
+Pulsar is all of us, feel free to contribute, discuss, answer questions and
+suggest ideas in any of our [community areas](./community.md).
+
+## The goals <!--See: https://github.com/orgs/pulsar-edit/discussions/50-->
+
+- Community developed, led and focused
+  - Pulsar is being made by a community who came together from the stellar
+    remnants of Atom. A community that wants to build upon the huge legacy that
+    was left and make a uniquely hackable editor.
+- To continue and build upon the legacy of the Atom text editor which is
+  being/has been sunset.
+  - This means not only supporting the editor itself but also the package
+    repository with its thousands of community contributions.
+- Update core technologies to bring the editor up to date.
+  - Core technologies such as Node.js, Electron etc., keeping them up to date so
+    new features and libraries can be used and added without hacky workarounds.
+- Emphasize the elements that make the editor great to really make Pulsar stand
+  out from the crowd, not only for ex-Atom users but for everyone.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,16 @@
+---
+title: Community areas
+path: /community/
+---
+
+Here you will find a number of community links to discuss Pulsar, get help,
+suggest features and enhancements and otherwise interact with the team and
+community.
+
+- [<i class="fa-solid fa-comments"></i> - GitHub Discussions](https://github.com/orgs/pulsar-edit/discussions)
+- [<i class="fa-brands fa-discord"></i> - Discord](https://discord.gg/7aEbB9dGRT)
+- [<i class="fa-brands fa-reddit"></i> - Reddit](https://www.reddit.com/r/pulsaredit/)
+
+If you wish to contribute to the running costs of the project we have an
+[OpenCollective](https://opencollective.com/pulsar-edit) where you can safely
+donate.

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -1,0 +1,32 @@
+---
+title: Pulsar Repositories
+path: /repos/
+---
+
+The Pulsar project is split up into a number of repositories, all hosted on
+GitHub.
+
+The very nature of the way Pulsar works means that there are a large number of
+packages that come together to make up the editor and each of these have their
+own repository.
+
+We also have a number of other repositories to host the website, package backend
+& frontend and our organization wide documentation & templates.
+
+All of the Pulsar repositories can be found under the organization at
+[https://github.com/pulsar-edit](https://github.com/pulsar-edit) but below is a
+list of some of the more regularly used ones you may wish to visit in order to
+contribute to the project.
+
+## Editor
+
+- [Pulsar](https://github.com/pulsar-edit/pulsar)
+- [PPM](https://github.com/pulsar-edit/ppm)
+
+## Websites and services
+
+- [Homepage & Documentation](https://github.com/pulsar-edit/pulsar-edit.github.io)
+- [Package Frontend](https://github.com/pulsar-edit/package-frontend)
+- [Package Backend](https://github.com/pulsar-edit/package-backend)
+- [GitHub Organization Files](https://github.com/pulsar-edit/.github)
+- [Assets](https://github.com/pulsar-edit/pulsar-assets)

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -16,7 +16,8 @@ We also have a number of other repositories to host the website, package backend
 All of the Pulsar repositories can be found under the organization at
 [https://github.com/pulsar-edit](https://github.com/pulsar-edit) but below is a
 list of some of the more regularly used ones you may wish to visit in order to
-contribute to the project.
+contribute to the project. For a more comprehensive list you can visit the
+org-level [REPOS file](https://github.com/pulsar-edit/.github/blob/main/REPOS.md).
 
 ## Editor
 


### PR DESCRIPTION
~~Relatively small~~ (edit: this is rapidly becoming less accurate) PR to update some parts of the website to just make it look nicer and flesh out a couple of areas.

Feel free to comment on any of the wording, I wrote most of this in the early hours of the morning...

- Added icons to the navbar links
- Added link to the new package frontend
- Removed discord link and replaced with a "community" dropdown + community home page 
  - Added links to reddit, GH discussions and opencollective
  - (Also had to add a child link to the "community home page" as apparently you cannot link the parent - let me know if this isn't right).
- Fleshed out content in "about us" note: left a comment linking to https://github.com/orgs/pulsar-edit/discussions/50 so that we can update this later when we have a consensus on exactly what to put in. This is just to get *something* in there.
- Added repo link to config (shows next to search box) that takes you to the GH org page.
- Added `repos` file and navbar link to list all of the common repositories being used in the spirit of being as open as possible and making it easy for newcomers.

Preview of new icons and re-organisation:
![image](https://user-images.githubusercontent.com/58074586/200174120-b3c7628e-6918-44ba-ba6b-41151f632164.png)
