### PR TITLE
Add tooling section

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -37,7 +37,13 @@ export default defineUserConfig({
     plugins: {
       mdEnhance: {
         align: true,
-        include:true,
+        include: {
+          getPath: (file) => {
+            if (file.startsWith("@orgdocs"))
+              return file.replace("@orgdocs", path.resolve(__dirname, "../../node_modules/.github/"));
+            return file;
+          },
+        },
         tabs: true,
         container: true
       },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -39,8 +39,10 @@ export default defineUserConfig({
         align: true,
         include: {
           getPath: (file) => {
-            if (file.startsWith("@orgdocs"))
-              return file.replace("@orgdocs", path.resolve(__dirname, "../../node_modules/.github/"));
+            if (file.startsWith("@orgdocs")) {
+              return file.replace("@orgdocs",
+                path.resolve(__dirname, "../../node_modules/.github/"));
+            }
             return file;
           },
         },

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -30,7 +30,8 @@ const sidebar_en = {
           collapsible: true,
           children: [
             'glossary/',
-            'pulsar-api/'
+            'pulsar-api/',
+            'tooling'
           ]
         },
         {

--- a/docs/docs/resources/index.md
+++ b/docs/docs/resources/index.md
@@ -1,3 +1,9 @@
 ---
 title: Resources
 ---
+
+A collection of miscellaneous resources around Pulsar and the project.
+
+- [Glossary](./glossary)
+- [Pulsar API](./pulsar-api)
+- [Project tooling](./tooling)

--- a/docs/docs/resources/tooling/index.md
+++ b/docs/docs/resources/tooling/index.md
@@ -1,0 +1,8 @@
+---
+title: Tooling
+---
+
+<!--This page is generated from the TOOLING.md page on the org-level
+documentation at https://github.com/pulsar-edit/.github-->
+
+@include(@orgdocs/TOOLING.md)


### PR DESCRIPTION
This PR adds a tooling section and integrates the tooling.md file from PR https://github.com/pulsar-edit/.github/pull/60 

To get this to work the `config.js` has been edited to make an alias in the `mdenhance` plugin so that the includes can read from a different dir for the given token (`@orgdocs`).

Sidebar has been edited to include the new tooling section as a child and I've created some text in the `resources/index.md` file with hyperlinks to the child sections.