### PR TITLE
Hide example post properly

### DIFF
--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -1,16 +1,24 @@
 ---
+title: Example post
+article: false
+---
+
+## <!--Everything below this line is the example post. The above is necessary just to hide it completely from the website-->
+
 title: Example Post
 author: Daeraxa
 date: 2022-11-12
 category:
-  - website
-  - testing
-tag:
-  - new feature
-  - placeholder
-sticky: false
-star: false
-article: false
+
+- website
+- testing
+  tag:
+- new feature
+- placeholder
+  sticky: false
+  star: false
+  article: false
+
 ---
 
 This is the excerpt.

--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -8,15 +8,14 @@ title: Example Post
 author: Daeraxa
 date: 2022-11-12
 category:
-
-- website
-- testing
-  tag:
-- new feature
-- placeholder
-  sticky: false
-  star: false
-  article: false
+  - website
+  - testing
+tag:
+  - new feature
+  - placeholder
+sticky: false
+star: false
+article: false
 ---
 
 This is the excerpt.

--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -3,7 +3,9 @@ title: Example post
 article: false
 ---
 
-## <!--Everything below this line is the example post. The above is necessary just to hide it completely from the website-->
+<!--Everything below this line is the example post. The above is necessary just to hide it completely from the website-->
+
+---
 
 title: Example Post
 author: Daeraxa

--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -2,11 +2,8 @@
 title: Example post
 article: false
 ---
-
 <!--Everything below this line is the example post. The above is necessary just to hide it completely from the website-->
-
 ---
-
 title: Example Post
 author: Daeraxa
 date: 2022-11-12
@@ -20,7 +17,6 @@ category:
   sticky: false
   star: false
   article: false
-
 ---
 
 This is the excerpt.

--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -7,18 +7,18 @@ article: false
 
 ---
 
-title: Example Post
-author: Daeraxa
-date: 2022-11-12
+title: Example Post  
+author: Daeraxa  
+date: 2022-11-12  
 category:
 
 - website
-- testing
+- testing  
   tag:
 - new feature
-- placeholder
+- placeholder  
   sticky: false
-  star: false
+  star: false  
   article: false
 
 ---

--- a/docs/blog/20221112-Daeraxa-ExamplePost.md
+++ b/docs/blog/20221112-Daeraxa-ExamplePost.md
@@ -7,18 +7,18 @@ article: false
 
 ---
 
-title: Example Post  
-author: Daeraxa  
-date: 2022-11-12  
+title: Example Post
+author: Daeraxa
+date: 2022-11-12
 category:
 
 - website
-- testing  
+- testing
   tag:
 - new feature
-- placeholder  
+- placeholder
   sticky: false
-  star: false  
+  star: false
   article: false
 
 ---


### PR DESCRIPTION
Noticed that the example post wasn't *completely* hidden from the website and could still be found by its tags and categories.

I've added a new frontmatter to hide it completely and an html comment to say only pick from below this line. Not ideal but not sure how else to easily hide it without setting up website filters or putting the file somewhere else.
I think it is easy enough to understand.

(All the extra commits are because of the commit hooks changing the file without me noticing...)