### PR TITLE
Update Atom archive

### DIFF
--- a/docs/docs/atom-archive/behind-atom/index.md
+++ b/docs/docs/atom-archive/behind-atom/index.md
@@ -2,6 +2,21 @@
 title: "Chapter 4 : Behind Atom"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom documentation. As this may no longer be relevant to Pulsar, use this at your own risk.
+Current Pulsar documentation is found at [documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## Behind Atom
 
 Now that we've written a number of packages and themes, let's take minute to take a closer look at some of the ways that Atom works in greater depth. Here we'll go into more of a deep dive on individual internal APIs and systems of Atom, even looking at some Atom source to see how things are really getting done.
+
+@include(./sections/configuration-api.md)
+@include(./sections/keymaps-in-depth.md)
+@include(./sections/scoped-settings-scopes-and-scope-descriptors.md)
+@include(./sections/serialization-in-atom.md)
+@include(./sections/developing-node-modules.md)
+@include(./sections/interacting-with-other-packages-via-services.md)
+@include(./sections/maintaining-your-packages.md)
+@include(./sections/how-atom-uses-chromium-snapshots.md)
+@include(./sections/summary.md)

--- a/docs/docs/atom-archive/behind-atom/sections/configuration-api.md
+++ b/docs/docs/atom-archive/behind-atom/sections/configuration-api.md
@@ -1,7 +1,3 @@
----
-title: Configuration API
----
-
 ### Configuration API
 
 #### Reading Config Settings

--- a/docs/docs/atom-archive/behind-atom/sections/developing-node-modules.md
+++ b/docs/docs/atom-archive/behind-atom/sections/developing-node-modules.md
@@ -1,7 +1,3 @@
----
-title: Developing Node Modules
----
-
 ### Developing Node Modules
 
 Atom contains a number of packages that are Node modules instead of Atom packages. If you want to make changes to the Node modules, for instance `atom-keymap`, you have to link them into the development environment differently than you would a normal Atom package.

--- a/docs/docs/atom-archive/behind-atom/sections/how-atom-uses-chromium-snapshots.md
+++ b/docs/docs/atom-archive/behind-atom/sections/how-atom-uses-chromium-snapshots.md
@@ -1,7 +1,3 @@
----
-title: How Atom Uses Chromium Snapshots
----
-
 ### How Atom Uses Chromium Snapshots
 
 In order to improve startup time, when Atom is built we create a [V8 snapshot](https://v8project.blogspot.it/2015/09/custom-startup-snapshots.html) in which we preload core services and packages. Then, at runtime, we finish loading Atom by supplying all the information we didn't have during the compilation phase (e.g. loading third party packages, custom style sheets, configuration, etc.).

--- a/docs/docs/atom-archive/behind-atom/sections/interacting-with-other-packages-via-services.md
+++ b/docs/docs/atom-archive/behind-atom/sections/interacting-with-other-packages-via-services.md
@@ -1,7 +1,3 @@
----
-title: Interacting With Other Packages Via Services
----
-
 ### Interacting With Other Packages Via Services
 
 Atom packages can interact with each other through versioned APIs called _services_. To provide a service, in your `package.json`, specify one or more version numbers, each paired with the name of a method on your package's main module:

--- a/docs/docs/atom-archive/behind-atom/sections/keymaps-in-depth.md
+++ b/docs/docs/atom-archive/behind-atom/sections/keymaps-in-depth.md
@@ -1,7 +1,3 @@
----
-title: Keymaps In-Depth
----
-
 ### Keymaps In-Depth
 
 #### Structure of a Keymap File

--- a/docs/docs/atom-archive/behind-atom/sections/maintaining-your-packages.md
+++ b/docs/docs/atom-archive/behind-atom/sections/maintaining-your-packages.md
@@ -1,7 +1,3 @@
----
-title: Maintaining Your Packages
----
-
 ### Maintaining Your Packages
 
 While publishing is, by far, the most common action you will perform when working with the packages you provide, there are other things you may need to do.

--- a/docs/docs/atom-archive/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
+++ b/docs/docs/atom-archive/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
@@ -1,7 +1,3 @@
----
-title: Scoped Settings, Scopes and Scope Descriptors
----
-
 ### Scoped Settings, Scopes and Scope Descriptors
 
 Atom supports language-specific settings. You can soft wrap only Markdown files, or set the tab length to 4 in Python files.

--- a/docs/docs/atom-archive/behind-atom/sections/serialization-in-atom.md
+++ b/docs/docs/atom-archive/behind-atom/sections/serialization-in-atom.md
@@ -1,7 +1,3 @@
----
-title: Serialization in Atom
----
-
 ### Serialization in Atom
 
 When a window is refreshed or restored from a previous session, the view and its associated objects are _deserialized_ from a JSON representation that was stored during the window's previous shutdown. For your own views and objects to be compatible with refreshing, you'll need to make them play nicely with the serializing and deserializing.

--- a/docs/docs/atom-archive/behind-atom/sections/summary.md
+++ b/docs/docs/atom-archive/behind-atom/sections/summary.md
@@ -1,7 +1,3 @@
----
-title: Summary
----
-
 ### Summary
 
 You should now have a better understanding of some of the core Atom APIs and systems.

--- a/docs/docs/atom-archive/getting-started/index.md
+++ b/docs/docs/atom-archive/getting-started/index.md
@@ -2,6 +2,13 @@
 title: "Chapter 1 : Getting started"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom
+documentation. As this may no longer be relevant to Pulsar, you use this at
+your own risk. Current Pulsar documentation for this section is found at the
+[documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## Getting Started
 
 This chapter is about getting started with Atom.

--- a/docs/docs/atom-archive/getting-started/sections/atom-basics.md
+++ b/docs/docs/atom-archive/getting-started/sections/atom-basics.md
@@ -1,10 +1,3 @@
-::: danger STOP
-This is being kept for archival purposes only from the original Atom
-documentation. As this may no longer be relevant to Pulsar, you use this at
-your own risk. Current Pulsar documentation for this section is found at the
-[documentation home](/docs/launch-manual/getting-started).
-:::
-
 #### Atom Basics
 
 Now that Atom is installed on your system, let's fire it up, configure it and

--- a/docs/docs/atom-archive/hacking-atom/index.md
+++ b/docs/docs/atom-archive/hacking-atom/index.md
@@ -2,6 +2,13 @@
 title: "Chapter 3 : Hacking Atom"
 ---
 
+::: danger STOP
+This is being kept for archival purposes only from the original Atom
+documentation. As this may no longer be relevant to Pulsar, you use this at
+your own risk. Current Pulsar documentation for this section is found at the
+[documentation home](/docs/launch-manual/getting-started).
+:::
+
 ## Hacking Atom
 
 Now it's time to come to the "Hackable" part of the Hackable Editor. As we've seen throughout the second section, a huge part of Atom is made up of bundled packages. If you wish to add some functionality to Atom, you have access to the same APIs and tools that the core features of Atom has. From the [tree-view](https://github.com/atom/tree-view) to the [command-palette](https://github.com/atom/command-palette) to [find-and-replace](https://github.com/atom/find-and-replace) functionality, even the most core features of Atom are implemented as packages.

--- a/docs/docs/atom-archive/hacking-atom/sections/creating-a-fork-of-a-core-package-in-atom-atom.md
+++ b/docs/docs/atom-archive/hacking-atom/sections/creating-a-fork-of-a-core-package-in-atom-atom.md
@@ -1,10 +1,7 @@
-<<<<<<< HEAD
-=======
 ---
 title: Creating a Fork of a Core Package in atom/atom
 ---
 
->>>>>>> acb39aa (Fixing stuff?)
 ## Creating a Fork of a Core Package in atom/atom
 
 Several of Atom's core packages are maintained in the [`packages` directory of the atom/atom repository](https://github.com/atom/atom/tree/master/packages). If you would like to use one of these packages as a starting point for your own package, please follow the steps below.

--- a/docs/docs/atom-archive/hacking-atom/sections/creating-a-fork-of-a-core-package-in-atom-atom.md
+++ b/docs/docs/atom-archive/hacking-atom/sections/creating-a-fork-of-a-core-package-in-atom-atom.md
@@ -1,7 +1,3 @@
----
-title: Creating a Fork of a Core Package in atom/atom
----
-
 ## Creating a Fork of a Core Package in atom/atom
 
 Several of Atom's core packages are maintained in the [`packages` directory of the atom/atom repository](https://github.com/atom/atom/tree/master/packages). If you would like to use one of these packages as a starting point for your own package, please follow the steps below.


### PR DESCRIPTION
There are a few changes here to fix the atom archive.

`Behind Atom` wasn't displaying at all as it had no includes so those have been added.

The other files have had some tweaks to remove any frontmatter titles.

Danger containers missing from index files have been added and, where necessary, removed from the section file.

There is one file I've altered the actual content of (Creating a Fork of a Core Package in atom/atom) because it has some odd data/comments which, whilst they might be present in the source files, do not display on the flight-manual website. These are just some weird comments that clearly aren't meant to be displayed.

i.e.
![image](https://user-images.githubusercontent.com/58074586/201504164-241f6506-ffde-4ec6-83bc-5e13565c413a.png)
