### PR TITLE
Add website guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,23 @@
-# Pulsar Edit
+# Pulsar Website ([https://pulsar-edit.dev](https://pulsar-edit.dev))
 
-This is the website repo for Pulsar Edit. It contains our documenation and other information users might be looking for. Visit the [Website](https://pulsar-edit.github.io).
+This is the website repo for Pulsar Edit. It contains our documentation and
+other information users might be looking for. Visit the [Website](https://pulsar-edit.dev).
 
-## Development
+Documentation relating to this repository and website can be found on the
+website at [http://pulsar-edit.dev/docs/resources/website/](http://pulsar-edit.dev/docs/resources/website/).
 
-The package manifest provides several scripts to help during development:
+Alternatively the source files for this documentation can be found on this
+repository in [pulsar-edit.github.io/docs/resources/website)](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website).
 
-### `dev`
+Useful sections of the documentation are linked below
 
-Starts a watch task that will rebuild VuePress whenever a change has been made to the included Markdown and JavaScript files. Additionally, it launches the development server to test the results in the browser.
-
-### `build`
-
-Creates an optimized production build.
-
-### `format`
-
-Runs [Prettier](https://prettier.io) over all Markdown files included in the repository to ensure consistent formatting.
-
-**Note:** This task will run automatically on every commit, so it can be ignored in most cases
-
-### `lint`
-
-Lints all Markdown files in the repository.
-
-**Note:** This task will run automatically on every commit, so it can be ignored in most cases
+- [Building the site](http://pulsar-edit.dev/docs/resources/website/#building-the-website)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/building.md)
+- [Configuration files](http://pulsar-edit.dev/docs/resources/website/#configuration-files)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/configuration-files.md)
+- [File organization](http:///pulsar-edit.dev/docs/resources/website/#file-organization)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/file-organization.md)
+- [Document style](http://pulsar-edit.dev/docs/resources/website/#documentation-style-reusable-components)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/document-style.md)
+- [Blog guide](http://pulsar-edit.dev/docs/resources/website/#blog-guide)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/blog-guide.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the website repo for Pulsar Edit. It contains our documentation and
 other information users might be looking for. Visit the [Website](https://pulsar-edit.dev).
 
 Documentation relating to this repository and website can be found on the
-website at [http://pulsar-edit.dev/docs/resources/website/](https://pulsar-edit.dev/docs/resources/website/).
+website at [https://pulsar-edit.dev/docs/resources/website/](https://pulsar-edit.dev/docs/resources/website/).
 
 Alternatively the source files for this documentation can be found on this
 repository in [pulsar-edit.github.io/docs/resources/website)](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website).

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ This is the website repo for Pulsar Edit. It contains our documentation and
 other information users might be looking for. Visit the [Website](https://pulsar-edit.dev).
 
 Documentation relating to this repository and website can be found on the
-website at [http://pulsar-edit.dev/docs/resources/website/](http://pulsar-edit.dev/docs/resources/website/).
+website at [http://pulsar-edit.dev/docs/resources/website/](https://pulsar-edit.dev/docs/resources/website/).
 
 Alternatively the source files for this documentation can be found on this
 repository in [pulsar-edit.github.io/docs/resources/website)](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website).
 
 Useful sections of the documentation are linked below
 
-- [Building the site](http://pulsar-edit.dev/docs/resources/website/#building-the-website)
+- [Building the site](https://pulsar-edit.dev/docs/resources/website/#building-the-website)
   - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/building.md)
-- [Configuration files](http://pulsar-edit.dev/docs/resources/website/#configuration-files)
+- [Configuration files](https://pulsar-edit.dev/docs/resources/website/#configuration-files)
   - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/configuration-files.md)
-- [File organization](http:///pulsar-edit.dev/docs/resources/website/#file-organization)
+- [File organization](https://pulsar-edit.dev/docs/resources/website/#file-organization)
   - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/file-organization.md)
-- [Document style](http://pulsar-edit.dev/docs/resources/website/#documentation-style-reusable-components)
+- [Document style](https://pulsar-edit.dev/docs/resources/website/#documentation-style-reusable-components)
   - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/document-style.md)
-- [Blog guide](http://pulsar-edit.dev/docs/resources/website/#blog-guide)
+- [Blog guide](https://pulsar-edit.dev/docs/resources/website/#blog-guide)
   - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/blog-guide.md)

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ Documentation relating to this repository and website can be found on the
 website at [https://pulsar-edit.dev/docs/resources/website/](https://pulsar-edit.dev/docs/resources/website/).
 
 Alternatively the source files for this documentation can be found on this
-repository in [pulsar-edit.github.io/docs/resources/website)](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website).
+repository in [pulsar-edit.github.io/docs/resources/website)](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website).
 
 Useful sections of the documentation are linked below
 
 - [Building the site](https://pulsar-edit.dev/docs/resources/website/#building-the-website)
-  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/building.md)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website/sections/building.md)
 - [Configuration files](https://pulsar-edit.dev/docs/resources/website/#configuration-files)
-  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/configuration-files.md)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website/sections/configuration-files.md)
 - [File organization](https://pulsar-edit.dev/docs/resources/website/#file-organization)
-  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/file-organization.md)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website/sections/file-organization.md)
 - [Document style](https://pulsar-edit.dev/docs/resources/website/#documentation-style-reusable-components)
-  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/document-style.md)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website/sections/document-style.md)
 - [Blog guide](https://pulsar-edit.dev/docs/resources/website/#blog-guide)
-  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/resources/website/sections/blog-guide.md)
+  - [Repo link](https://github.com/pulsar-edit/pulsar-edit.github.io/tree/main/docs/docs/resources/website/sections/blog-guide.md)

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -60,6 +60,11 @@ const sidebar_en = {
             text: 'Tooling',
             icon: 'solid fa-toolbox',
             link: 'tooling/'
+          },
+          {
+            text: 'Website',
+            icon: 'solid fa-table-columns',
+            link: 'website/'
           }
         ]
       },

--- a/docs/docs/resources/website/index.md
+++ b/docs/docs/resources/website/index.md
@@ -1,0 +1,16 @@
+---
+title: Website
+---
+
+Here is all the information on how the Pulsar website is built and configured.
+
+The website itself is built using [VuePress v2](https://v2.vuepress.vuejs.org/)
+and the [Vuepress Hope Theme](https://vuepress-theme-hope.github.io/).
+
+See the documentation there for generic items not covered in this guide.
+
+@include(sections/building.md)
+@include(sections/configuration-files.md)
+@include(sections/file-organization.md)
+@include(sections/document-style.md)
+@include(sections/blog-guide.md)

--- a/docs/docs/resources/website/sections/blog-guide.md
+++ b/docs/docs/resources/website/sections/blog-guide.md
@@ -1,4 +1,4 @@
-# Blog guide
+## Blog guide
 
 This is a guide on how to add a blog post to the website which will be shown on
 [http://pulsar-edit.dev/article/](http://pulsar-edit.dev/article/).
@@ -9,7 +9,7 @@ to suit our purposes.
 
 This is all implemented in the main [website repository](https://github.com/pulsar-edit/pulsar-edit.github.io).
 
-## Writing a new post
+### Writing a new post
 
 - Create a new .md file in pulsar-edit.github.io/docs/blog.
   - This file should be named `YYYYMMDD-<author>-<title>.md` e.g `20221031-CreativeUsername-ThisIsMyBlogPost.md`
@@ -54,13 +54,11 @@ This is all implemented in the main [website repository](https://github.com/puls
 See [example post](./docs/blog/20221112-Daeraxa-ExamplePost.md) with everything
 above.
 
-## Testing locally
+### Testing locally
 
-After cloning the repo run `pnpm install` followed by `pnpm dev`.
-New articles will not be picked up automatically so you will need to stop the
-server and run `pnpm dev` again.
+See [building](../#building-the-website)
 
-## Website "Blog" page(s)
+### Website "Blog" page(s)
 
 The website itself has a number of features which the aforementioned frontmatter
 fields can influence.
@@ -78,7 +76,7 @@ submitted in the respective frontmatter fields.
 The `Timeline` allows views of blog posts over time according to the dates set
 in the `date` frontmatter field.
 
-## Questions? Suggestions
+### Questions? Suggestions
 
 Just ask in Discord or GH Discussions and ping the `@documentation` team.
 

--- a/docs/docs/resources/website/sections/blog-guide.md
+++ b/docs/docs/resources/website/sections/blog-guide.md
@@ -1,7 +1,7 @@
 ## Blog guide
 
 This is a guide on how to add a blog post to the website which will be shown on
-[http://pulsar-edit.dev/article/](http://pulsar-edit.dev/article/).
+[https://pulsar-edit.dev/article/](https://pulsar-edit.dev/article/).
 
 We are using the [Vuepress Blog Plugin](https://vuepress-theme-hope.github.io/v2/blog/)
 which comes as part of our Vuepress Hope Theme with some light configuration

--- a/docs/docs/resources/website/sections/building.md
+++ b/docs/docs/resources/website/sections/building.md
@@ -1,0 +1,62 @@
+## Building the website
+
+### Prerequisites
+
+- Node.js - at least version 16 (recommended install via [nvm](https://github.com/nvm-sh/nvm)).
+- git
+- [pnpm](https://pnpm.io/) - simply run `corepack enable`
+
+### Clone the repository and install
+
+The website repository is [https://github.com/pulsar-edit/pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io).
+Other assets are stored on other repositories but these will be downloaded
+automatically.
+
+```sh
+git clone https://github.com/pulsar-edit/pulsar-edit.github.io
+
+cd pulsar-edit.github.io
+
+pnpm install
+```
+
+### Running the website
+
+Once installed there are a number of scripts available to help you develop
+and build the site. Just prefix each command with `pnpm`. e,g, `pnpm dev`.
+
+#### `dev`
+
+Starts a watch task that will rebuild VuePress whenever a change has been made
+to the included Markdown and JavaScript files. Additionally, it launches the
+development server to test the results in the browser.
+
+#### `build`
+
+Creates an optimized production build.
+
+#### `format`
+
+Runs [Prettier](https://prettier.io) over all Markdown files included in the
+repository to ensure consistent formatting.
+
+**Note:** This task will run automatically on every commit, so it can be ignored
+in most cases
+
+#### `lint`
+
+Lints all Markdown files in the repository.
+
+**Note:** This task will run automatically on every commit, so it can be ignored
+in most cases
+
+### Notes
+
+Whilst `dev` does run a watch task, not everything will be updated and some
+changes will require you to shut down the server and start it again. For example
+adding `@include` files to another file will not rebuild automatically.
+
+If you wish to add new files from another repository via alias or `@include`
+then you will need to run `pnpm update` to get the latest version of the
+repository - the `pnpm-lock.yml` file will also be updated and must be part of
+any commit.

--- a/docs/docs/resources/website/sections/building.md
+++ b/docs/docs/resources/website/sections/building.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites
 
-- Node.js - at least version 16 (recommended install via [nvm](https://github.com/nvm-sh/nvm)).
+- Node.js - at least version 16 (recommended installation via [nvm](https://github.com/nvm-sh/nvm)).
 - git
 - [pnpm](https://pnpm.io/) - simply run `corepack enable`
 

--- a/docs/docs/resources/website/sections/configuration-files.md
+++ b/docs/docs/resources/website/sections/configuration-files.md
@@ -22,7 +22,7 @@ This file is broken down to to keep it tidy, the below files are imported to
 This controls the layout for the links in the top middle of the page and is
 always displayed.
 
-Items that go here are ones that we always want to be show and should always
+Items that go here are ones that we always want to be shown and should always
 be available for quick navigation.
 
 Each object can have a number of different values. The main ones we use are:

--- a/docs/docs/resources/website/sections/configuration-files.md
+++ b/docs/docs/resources/website/sections/configuration-files.md
@@ -1,0 +1,79 @@
+## Configuration files
+
+Nearly everything regarding the configuration of the website itself is
+controlled via the files found in the `/docs/.vuepress` directory.
+
+Currently we have three main configuration files.
+
+### `config.js`
+
+This is the main configuration file for the website. This controls everything
+from the available settings, additional VuePress plugins, website description
+and various other elements to control various settings and plugins.
+
+For a full reference you can look at the documentation for [VuePress](https://v2.vuepress.vuejs.org/reference/config.html)
+and the [Hope Theme](https://vuepress-theme-hope.github.io/v2/config/).
+
+This file is broken down to to keep it tidy, the below files are imported to
+`config.js` to extend the configuration file without making it unwieldy.
+
+### `navbar.js`
+
+This controls the layout for the links in the top middle of the page and is
+always displayed.
+
+Items that go here are ones that we always want to be show and should always
+be available for quick navigation.
+
+Each object can have a number of different values. The main ones we use are:
+
+- `text`: This sets the text for the label.
+- `icon`: Used to prefix an icon to the item. The theme supports the free
+  [FontAwesome](https://fontawesome.com/) font natively. To add an icon you need
+  to specify its name without the first `fa-` e.g. [fa-house](https://fontawesome.com/icons/house?s=solid&f=classic)
+  would be specified as `solid fa-house`.
+- `link`: This controls where the link will actually take you. This can be
+  a relative reference internal to the website or can be a URL to an external
+  site.
+- `children`: Allows you to specify an array of child objects which will appear
+  as a dropdown on mouseover. Use of this disables the `link` value. Each child
+  can be defined as a full object as described here or can simply be a relative
+  link from which the text will be set by the YAML title.
+
+For a full reference you can look at the documentation for [VuePress](https://v2.vuepress.vuejs.org/reference/default-theme/config.html#navbar)
+and the [Hope Theme](https://vuepress-theme-hope.github.io/v2/config/theme/layout.html#navbar-config).
+
+### `sidebar.js`
+
+This control what is displayed in the sidebar on the left of the website. It is
+not displayed globally, only on directories which are set within the sidebar,
+currently we only have `docs` configured.
+
+Like `navbar.js` each sidebare item is configured as an object with a number of
+different values.
+
+- `text`: This sets the text for the label.
+- `link`: Controls the relative link for navigating the documents within the
+  section
+- `icon`: Used to prefix an icon to the item. The theme supports the free
+  [FontAwesome](https://fontawesome.com/) font natively. To add an icon you need
+  to specify its name without the first `fa-` e.g. [fa-house](https://fontawesome.com/icons/house?s=solid&f=classic)
+  would be specified as `solid fa-house`.
+- `prefix`: This adds a file path prefix to the item so its children do not
+  need to specify the full path.
+- `collapsable`: (sic) Controls whether the item can be collapsed. _Note_: This
+  a breaking change on a future version of the Hope Theme so will need to be
+  renamed `collapsible` when updated, see: [Issue](https://github.com/vuepress-theme-hope/vuepress-theme-hope/issues/2377).
+- `children`: Takes an array of objects configured as above. Can also be set as
+  a simple relative link in which case the title will be the YAML title of the
+  document it links to.
+
+For a full reference you can look at the documentation for [VuePress](https://v2.vuepress.vuejs.org/reference/default-theme/config.html#sidebar)
+and the [Hope Theme](https://vuepress-theme-hope.github.io/v2/config/theme/layout.html#sidebar-config).
+
+### Theme
+
+Within the `styles/` directory you will find the .scss file for controlling
+various aspects of the website's theme.
+
+**_TODO_**: This will be updated when we actually modify these files extensively.

--- a/docs/docs/resources/website/sections/document-style.md
+++ b/docs/docs/resources/website/sections/document-style.md
@@ -1,4 +1,4 @@
-# Documentation style & reusable components
+## Documentation style & reusable components
 
 The documentation for the project should maintain a consistent style where
 possible. This covers a number of aspects such as writing style, naming
@@ -6,7 +6,7 @@ conventions, folder structure, links etc.
 
 All docs are currently in American English (en-US) but localization is planned.
 
-## Structure
+### Structure
 
 The main structure for documentation can be seen in `docs/docs`.
 There are a number of "root" sections:
@@ -14,18 +14,19 @@ There are a number of "root" sections:
 - `launch-manual` - For the current main Pulsar documentation
 - `packages` - Currently holds wiki info from the atom package repos
 - `resources` - For other referenced docs
+- `blog` - For the website blog
 - `atom-archive` - For "as is" archived Atom documentation
 
 Within each section is an `index.md` which will usually contain info about each
-sub-section as well as links to them. These correspond to the second level 
+sub-section as well as links to them. These correspond to the second level
 items on the sidebar.
 
 Inside `sections` are the sub-sections which group more specific topics. These
 also have an `index.md` which corresponds to the third level item on the
-sidebar. 
+sidebar.
 This file is displayed on the website as a single long documenent but is
 actually created from a number of @include() lines which reference individual
-sections within the next sections directory. These should be relative to the 
+sections within the next sections directory. These should be relative to the
 location of index.md e.g. @include(sections/pulsar-packages.md).
 This file also contains the frontmatter for defining the title, language and
 description of the file and should also be the first level heading for the page.
@@ -34,9 +35,9 @@ apply to the entire page.
 
 Inside the next `sections` directory should be the actual content of the
 document. Each section should start with a second level header and should
-not contain any frontmatter. 
+not contain any frontmatter.
 
-## Links
+### Links
 
 Internal links can just be to the header (e.g.`[Structure](#structure)`), this
 to all sections included on the parent `index.md` so care should be made to not
@@ -52,7 +53,7 @@ the `.vuepress/config.js` file which adds most of the path for you:
 `'@images': path.resolve(__dirname, '../../node_modules/pulsar-assets/images')`  
 so the link to your image would just be `![myImage](@images/pulsar/myImage.png "My Image")`.
 
-## Naming
+### Naming
 
 The name of the application is `Pulsar` and should be capitalized as such.
 Whilst the website and GitHub org name is `Pulsar-Edit`, this should not be used
@@ -70,6 +71,7 @@ When using the `#tabs` switcher they should be in this order.
 
 When referencing them inline then they should be abbreviated to the following, strongly emphasized and
 separated by a `-`:
+
 - Linux = **_LNX_**
 - macOS = **_MAC_**
 - Windows = **_WIN_**
@@ -80,24 +82,26 @@ MAC/WIN
 
 For Linux we may sometimes need to reference particular distros or families of
 distributions. We currently use:
+
 - `Ubuntu/Debian` for all distributions based on Debian or Ubuntu
 - `Fedora/RHEL` for all distrububtions based on Fedora Linux & Red Hat
-                Red Hat Enterprise Linux. This includes AlmaLinux, CentOS, Rocky
-                Linux etc.
+  Red Hat Enterprise Linux. This includes AlmaLinux, CentOS, Rocky
+  Linux etc.
 - `Arch` - for all Arch based distributions such as Manjaro, Garuda, ArcoLinux
-           etc.
+  etc.
 - `OpenSUSE` - for all OpenSUSE based distributions such as GeckoLinux
 
-We may need to add more in the future but generally users of less popular or 
+We may need to add more in the future but generally users of less popular or
 more technical distributions such as Gentoo or NixOS understand how to
 adapt to their OS from the instructions above.
 
-## Containers
+### Containers
 
 Where you want to display an `info`, `warning` or tab/code switcher in the
 document you should use a container with the `:::` syntax.
 
-e.g. 
+e.g.
+
 ```
 ::: tabs#filename
 
@@ -117,6 +121,7 @@ Lorem ipsum dolor sit amet...
 ```
 
 or
+
 ```
 ::: tip My Helpful Tip
 
@@ -130,6 +135,6 @@ various purposes at [pulsar-edit.github.io/common-text-blocks.md](https://github
 
 See [VuePress Hope documentation](https://vuepress-theme-hope.github.io/v2/guide/get-started/markdown.html#theme-enhancement)
 
-## Writing style
+### Writing style
 
 TODO: Needs consensus

--- a/docs/docs/resources/website/sections/file-organization.md
+++ b/docs/docs/resources/website/sections/file-organization.md
@@ -1,0 +1,105 @@
+## File Organization
+
+One of the most important things to take note of when adding new documentation
+is where is should go within the website layout.
+
+The generalized overall layout of the website looks like this:
+
+```
+docs
+├── root level .md files
+└── section folder
+    ├── sections
+    └── index.md
+```
+
+The general idea is that for files that can stand by themselves (for example
+the `About Us` page, `Repositories` etc.) they exist at the `docs/` "root"
+level.
+
+For anything that is more complex it needs to have a section directory named
+appropriately, an `index.md` file within it and a `sections` directory.
+
+### `index.md`
+
+This index file needs to have a YAML frontmatter to define, at a minimum, the
+title of the document. This is displayed as an `H1` header for the page (note:
+subsequent `H1` headers will be ignored so always start at `H2`).
+
+The rest of this index file will be used to display the actual content you want
+to show. This is done in a number of ways.
+
+First of all you can just include standard markdown. This is often used for
+introducing the section or adding one of our reusable components (e.g. a
+`danger` container).
+
+The rest of the file should consist of `@includes` which take data from
+other folders on the website and integrates it automatically. Usually this will
+be the `sections` files which will be covered next.
+
+e.g.
+
+```
+@include(sections/file-organization.md)
+```
+
+However you can also use `@include` to feature files from a different section of
+the website or even files from outside the main site. We use this to include
+files which are maintained on the organization [.github repo](https://github.com/pulsar-edit/.github)
+for org-level documents.
+
+This is done by having a value defined on the `config.js` file which will
+provide an alias for us to use:
+
+```js
+if (file.startsWith("@orgdocs")) {
+	return file.replace(
+		"@orgdocs",
+		path.resolve(__dirname, "../../node_modules/.github/")
+	);
+}
+```
+
+This allows us to include org-level docs by using this special alias.
+
+e.g.
+
+```
+@include(@orgdocs/TOOLING.md)
+```
+
+### Sections
+
+The `sections` directory is where we include the rest of the documents broken
+down by section. These should be self contained files which can be used alone
+but are designed to be included on the section page. This approach allows us
+flexibility with ordering as well as including these files in other places
+without needing to duplicate the material.
+
+Files here can be navigated to directly on the website but should not be linked
+to directly.
+
+These files shoud _not_ have any YAML frontmatter as they will be included
+and shown as text.
+
+### Assets
+
+Assets should be uploaded to the [.github repo](https://github.com/pulsar-edit/.github/tree/main/images/)
+repository so they can be used org-wide.
+
+An alias for this exists in `config.js` to access files from this repository.
+
+```js
+alias: {
+  '@images': path.resolve(__dirname, '../../node_modules/.github/images')
+},
+```
+
+So to include an image you simply need to use the standard markdown image link
+along with the alias:
+
+e.g.
+
+```md
+![MyImage](@images/path/to/image.png)
+```


### PR DESCRIPTION
This is a fairly large PR that adds a guide to how the website is configured, how to add new files etc. 

As part of this I've also done some reorganising to make better sense of things.

The new content is all in the `docs/resources/website` section.

Changes:
- README.md edited as the info here is now added to the guide and instead this serves as an index to find the files within it. I've added both the website URL and the repo link to the file in case the website is unavailable
- blog-guide.md moved into the website guide and headers incremented
- documentation-style moved into the website guide headers incremented

~~This is currently set to a draft as I am waiting on https://github.com/pulsar-edit/pulsar-edit.github.io/pull/99 to be merged (with any changes required) before I add the website guide to the sidebar.~~ This has now been added and converted to a normal PR.
