### PR TITLE
Add atom_electron_version

### DIFF
--- a/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
+++ b/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
@@ -6,6 +6,8 @@ hoops you have to jump through to get it to work correctly.
 
 After following the build instructions you will find the `ppm` binary at
 `pulsar/ppm/bin/apm` but by default Pulsar will be looking in the wrong place.
+There will also be issues relating to the Electron version which will prevent
+install from the package backend.
 To solve this a couple of environmental variables need to be exported.
 
 ::: tabs
@@ -15,6 +17,7 @@ To solve this a couple of environmental variables need to be exported.
 ```sh
 export ATOM_HOME=/home/<user>/.pulsar
 export APM_PATH=/ppm/bin/apm
+export ATOM_ELECTRON_VERSION=12.2.3
 ```
 
 @tab macOS


### PR DESCRIPTION
Adds the ATOM_ELECTRON_VERSION variable to the current build help docs.

See [Discord](https://discord.com/channels/992103415163396136/992103415163396139/1029200155662102548), [more Discord](https://discord.com/channels/992103415163396136/992109539346370661/1028735476628213780) and [even more Discord](https://discord.com/channels/992103415163396136/992103415163396139/1044752947873062942)