### PR TITLE
Fix edit links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -31,6 +31,8 @@ export default defineUserConfig({
     iconAssets: "fontawesome",
     repo: "pulsar-edit",
     repoLabel: "GitHub",
+    docsRepo: "https://github.com/pulsar-edit/pulsar-edit.github.io",
+    docsDir: "/docs",
     navbar: navbar_en,
     locales: {
       "/": {


### PR DESCRIPTION
Adds the `docsRepo` and `docsDir` config options to the theme to fix the "edit this page" link which leads to the wrong location due to it using the `repo` option by default.