### PR TITLE
Added Sitemap

### DIFF
--- a/docs/.vuepress/public/sitemap.xml
+++ b/docs/.vuepress/public/sitemap.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://pulsar-edit.dev/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/download.html</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/about.html</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/article/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/launch-manual/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/packages/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/resources/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/resources/glossary/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/resources/pulsar-api/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/resources/tooling/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/resources/website/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.2</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/getting-started/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/using-atom/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/hacking-atom/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/behind-atom/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/api/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/resources/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/faq/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/shadow-dom/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/upgrading-to-1-0-apis/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+  <url>
+    <loc>https://pulsar-edit.dev/docs/atom-archive/atom-server-side-apis/</loc>
+    <lastmod>2022-11-24</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.1</priority>
+  </url>
+
+</urlset>


### PR DESCRIPTION
This PR adds a sitemap to the main website, in the default supported location for Vuepress.

I attempted to add all pages that we would want to be relevant to the sitemap, as well as when assigning priority, wrote them as if I was an end user. With the homepage having the highest priority (`1.0`), our downloads page next (`0.9`), then our documentation homepage (`0.8`), and from there, the rest where following a bit below that of the default or just above. The only other note would be that all original Atom Archived docs have been given a `0.1` priority, to still ensure they are indexed, but are marked as low priority. While additionally specifying that they should never change.

---

Also edit on why I didn't just use a prebuilt plugin for this, personally the only one I found that seemed simple enough to implement still seemed to require use to make it manually if we wanted to assign proper priority, just in JSON. So this seemed to be the simplest route to go