### PR TITLE
remove copyright config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -36,6 +36,7 @@ export default defineUserConfig({
     repoLabel: "GitHub",
     displayFooter: true,
     footer: footer,
+    copyright: false,
     docsRepo: "https://github.com/pulsar-edit/pulsar-edit.github.io",
     docsDir: "/docs",
     navbar: navbar_en,


### PR DESCRIPTION
Noticed that the default copyright option broke the formatting for the website footer.
We can add it back in if we need its features (for example the atom docs licence).

Only noticed as it on a blog post as it created a new copyright line next to the original.