### PR TITLE
Fix footer links

### DIFF
--- a/docs/.vuepress/footer.js
+++ b/docs/.vuepress/footer.js
@@ -139,7 +139,7 @@ const footer =
         <div class="linksBoxContent">
           <ul>
             <li>
-              <a href="/download/"> Downloads </a>
+              <a href="/download.html"> Downloads </a>
             </li>
             <li>
               <a href="/docs/"> Documentation </a>
@@ -156,7 +156,7 @@ const footer =
         <div class="linksBoxContent">
           <ul>
             <li>
-              <a href="/about/"> About Us </a>
+              <a href="/about.html"> About Us </a>
             </li>
             <li>
               <a href="/article/"> Blog </a>


### PR DESCRIPTION
See https://discord.com/channels/992103415163396136/992275353961775145/1047177682967855196

Footer links don't resolve quickly to the page and show an intermediate and noticeable 404 page. Noticed on about us and download.

This changes the links to the direct html link. The index.md links aren't affected (like docs).