### PR TITLE
Fix footer style for mobile

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -8,6 +8,20 @@
 
 //Website footer section
 
+@media (max-width: 719px) {
+  .footer-wrapper {
+    padding-left: 0rem;
+  }
+}
+
+.no-sidebar .footer-wrapper {
+    padding-left: 0rem;
+}
+
+.footer {
+  width: 25%;
+}
+
 .socialsBar {
   display: flex;
   gap: 25px;
@@ -20,20 +34,21 @@
   flex-direction: row;
   justify-content: space-between;
   width: 100%;
+  align-items: stretch;
 }
 
 .linksBoxLeft {
-  margin: 0px 60px 0px 0px;
+  padding: 0px 10px 0px 0px;
   text-align: left;
 }
 
 .linksBoxMid {
-  margin: 0px 60px 0px 60px;
+  padding: 0px 10px 0px 10px;
   text-align: left;
 }
 
 .linksBoxRight {
-  margin: 0px 0px 0px 60px;
+  padding: 0px 0px 0px 10px;
   text-align: left;
 }
 
@@ -52,6 +67,15 @@
   padding: 0px;
 }
 
+.linksBoxContent li {
+  margin-bottom: 2px;
+}
+
+.linksBoxContent a {
+  display:inline-block;
+  line-height: 1.2;
+}
+
 .copyrightBar {
 
 }
@@ -61,4 +85,5 @@
   fill-opacity:1;
   height: 50px;
   margin: 10px 0px 20px 0px;
+  width: auto;
 }


### PR DESCRIPTION
Reported here - https://discord.com/channels/992103415163396136/992275353961775145/1047346852791599155

Footer was not responsive so caused display issues on mobile.

![image](https://user-images.githubusercontent.com/58074586/204944483-4c204ecd-c0ef-4edf-be57-6ebebbfe0b28.png)


This also needed a number of other fixes, it seems that for some reason a left padding was added on a particular media query as well as if there is no sidebar (the latter makes sense on desktop where the sidebar element can be collapsed but remains in view). 

These changes override the media query and no-sidebar behaviour to centre the footer on mobile.

Also added an adjustment to the line spacing when the list items in the footer are wrapped to make it more obvious that they are wrapped and not separate items.

As ever I invite those more skilled in CSS to look at this and fix anything that is abhorrent to them.

Before:
![image](https://user-images.githubusercontent.com/58074586/204944233-c56053d3-3b34-47d1-a361-be798cf0051a.png)

After:
![image](https://user-images.githubusercontent.com/58074586/204944248-15113c7c-6862-48ae-bc3f-ce8f9370ef93.png)
