### PR TITLE
Super Simple PR - Fixed Caps on `subreddit`

### DIFF
--- a/docs/docs/launch-manual/sections/faq/sections/get-help.md
+++ b/docs/docs/launch-manual/sections/faq/sections/get-help.md
@@ -3,7 +3,7 @@
 If you have any issues then please feel free to ask for help from the Pulsar Team:
 
 - [Discord server](https://discord.gg/7aEbB9dGRT)
-- [subreddit](https://www.reddit.com/r/pulsaredit/)
+- [Subreddit](https://www.reddit.com/r/pulsaredit/)
 - [GitHub Discussions](https://github.com/pulsar-edit/pulsar/discussions)
 
 If you think you have found a bug then please create a


### PR DESCRIPTION
Our Get Help section uses `subreddit` where it should be `Subreddit`

This PR fixes that.