### PR TITLE
Add a notice section to the website homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,55 @@ features:
   - title: "Find and replace"
     details: "Find, preview, and replace text as you type in a file or across all your projects."
 ---
+
+## Notices
+
+::: info Welcome
+
+Welcome to all new visitors!
+
+This project is still very new and the team is still working hard on a number
+of areas of the whole project. That includes the website, package repository and
+GitHub organisation as well as the editor itself.
+
+The below is just some items that we are currently working on that might answer
+any questions you have at this early stage of the project.
+
+### Downloads and Releases
+
+We are still working on the editor to get to our first stable release.
+You can still download a binary of Pulsar by following [this link](https://pulsar-edit.dev/download.html#cirrus-ci-binaries)
+and following the instructions.
+
+We are looking to support distro repositories such as Debian/Ubuntu repos,
+Fedora, Snap, Flatpak, Arch/AUR etc. but we need to get to a good point with
+a stable release before we instigate that so for now the downloadable binaries
+are the main supported downloads.
+
+### Packages
+
+One of our first and biggest tasks was to replace the closed source Atom.io
+package repository with our own so that users would still be able to download
+from the huge package ecosystem
+
+Currently searching and downloading from the [package repository](https://web.pulsar-edit.dev/)
+is fully functional but other functions for maintaining packages such as
+publishing/updating/deleting are not yet functional.
+
+### Pulsar
+
+The releases do seem to be working for most people and use cases but if you
+have any problems then please do let us know in one of our [community areas](https://pulsar-edit.dev/community.html)
+or as a [GitHub issue](https://github.com/pulsar-edit/pulsar/issues/new?assignees=&labels=bug%2Ctriage&template=bug-report.yml)
+
+### Logos, branding and website design
+
+You may notice a lot of inconsistencies with colors, logos and general website
+design. We are very aware of this but our main focus is getting everything
+functional first and sort out the design later as the Atom sunset is fast
+approaching.
+We are still waiting on a finalized design for the branding (color schemes,
+final logo colors etc.) so most of what you see are just placeholders and will
+likely be updated shortly - the website design will then follow.
+
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,11 @@ The releases do seem to be working for most people and use cases but if you
 have any problems then please do let us know in one of our [community areas](https://pulsar-edit.dev/community.html)
 or as a [GitHub issue](https://github.com/pulsar-edit/pulsar/issues/new?assignees=&labels=bug%2Ctriage&template=bug-report.yml)
 
+#### Known Issues
+
+- MacOS Performance: Currently performance on MacOS isn't what we hope to achieve. Often times this can be resolved by disabling the `github` package.
+- Windows Package Installation: In the newer versions of our binaries, Windows systems will fail to install external packages. This can be resolved by using an older binary or installing from GitHub.
+
 ### Logos, branding and website design
 
 You may notice a lot of inconsistencies with colors, logos and general website

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,6 @@ or as a [GitHub issue](https://github.com/pulsar-edit/pulsar/issues/new?assignee
 #### Known Issues
 
 - MacOS Performance: Currently performance on MacOS isn't what we hope to achieve. Often times this can be resolved by disabling the `github` package.
-- Windows Package Installation: In the newer versions of our binaries, Windows systems will fail to install external packages. This can be resolved by using an older binary or installing from GitHub.
 
 ### Logos, branding and website design
 


### PR DESCRIPTION
This is very much designed to be a temporary measure - at least in its current format.

It isn't very pretty, it is designed entirely to be functional and obvious at this point.

The idea of this is to try to pre-emptively answer some common questions about the project but aren't necessarily things we want to keep in an FAQ doc - this would be designed to be changed quickly as and when we need it until we are at a point where we no longer require it (for example branding and website is "finalised", packages can be published to the backend, downloads links are sorted and we are in repos etc.

Feel free to add or adjust the content as part of the review.