### PR TITLE
Fix footer formatting

### DIFF
--- a/docs/.vuepress/footer.js
+++ b/docs/.vuepress/footer.js
@@ -11,9 +11,7 @@ const donateLink = "https://opencollective.com/pulsar-edit";
 
 
 const footer =
-  `<div>
-
-    <!--<div><object type="image/svg+xml" data="/logo-name-footer.svg" ></object></div>TODO: Fix - I have simply run out of talent to make this work correctly with external CSS or modifying the internal values. At I can get this to do what I want when the SVG is inline-->
+  `<!--<div><object type="image/svg+xml" data="/logo-name-footer.svg" ></object></div>TODO: Fix - I have simply run out of talent to make this work correctly with external CSS or modifying the internal values. At I can get this to do what I want when the SVG is inline-->
 
     <!--The below inline SVG is the same code (with unnecessary inkscape values removed) as is in .vuepress/public/logo-name-footer.svg but inline so I can actually manipulate it with the index.css file-->
 
@@ -193,7 +191,6 @@ const footer =
 
   <div class="copyrightBar">
     <span> Pulsar-Edit © 2022 </span>
-  </div>
   </div>`
 
 export { footer as footer };

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -8,18 +8,16 @@
 
 //Website footer section
 
+//Theme adds a sidebar width even on mobile when it doesnt show, this removes it.
 @media (max-width: 719px) {
-  .footer-wrapper {
+.no-sidebar .footer-wrapper, .footer-wrapper {
     padding-left: 0rem;
   }
 }
 
-.no-sidebar .footer-wrapper {
-    padding-left: 0rem;
-}
-
 .footer {
-  width: 25%;
+  width: 100%;
+  max-width: 1000px;
 }
 
 .socialsBar {
@@ -29,33 +27,46 @@
   justify-content: center;
 }
 
+// To allow wrapping on very narrow screens
+@media (max-width: 350px) {
+  .socialsBar {
+    flex-wrap: wrap;
+  }
+}
+
 .linksBox {
   display: flex;
+  gap: 25px;
   flex-direction: row;
-  justify-content: space-between;
-  width: 100%;
-  align-items: stretch;
+  justify-content: center;
+  align-items: center;
+}
+
+// Snaps to single column on very narrow screens
+@media (max-width: 350px) {
+  .linksBox {
+    flex-direction: column;
+  }
 }
 
 .linksBoxLeft {
-  padding: 0px 10px 0px 0px;
   text-align: left;
+  margin: auto;
 }
 
 .linksBoxMid {
-  padding: 0px 10px 0px 10px;
   text-align: left;
+  margin: auto;
 }
 
 .linksBoxRight {
-  padding: 0px 0px 0px 10px;
   text-align: left;
+  margin: auto;
 }
 
 .linksBoxHeader {
   font-weight: bold;
   font-size: 20px;
-  margin: 0px;
 }
 
 .linksBoxContent, .linksBoxContent a {
@@ -71,6 +82,8 @@
   margin-bottom: 2px;
 }
 
+// Sets the line height for wrapped text when the boxes are shrunk to make the
+// separation obvious
 .linksBoxContent a {
   display:inline-block;
   line-height: 1.2;


### PR DESCRIPTION
Fix the footer... again.

This is a pretty extensive redo of the footer in terms of settings widths, max widths etc. and takes into account very narrow screens.

Now rather than the footer acting responsively to all widths it will maintain its style until under a certain width and will start shrinking.

The socials and link items will now wrap on narrow screens <350px.

As ever this is mostly me flailing away with CSS to make things work so if anyone knows better, feel free to chime in.