### PR TITLE
Add Cirrus binary download links

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -6,6 +6,14 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Jura:wght@500&display=swap');
 
+//Container formatting
+//Annoyingly the table takes on the details background which makes it look odd so this overrides some of it until we sort the overall theme out.
+.custom-container.details table {
+  display: table;
+  background-color: #FAFAFA;
+  width: 75%;
+}
+
 //Website footer section
 
 //Theme adds a sidebar width even on mobile when it doesnt show, this removes it.

--- a/docs/download.md
+++ b/docs/download.md
@@ -20,6 +20,12 @@ dev/beta releases of Pulsar or [build from source](https://pulsar-edit.dev/docs/
 
 ## Cirrus CI binaries
 
+Binaries are produced by [Cirrus CI](https://cirrus-ci.com/github/pulsar-edit/pulsar)
+for each commit to the Pulsar repository.  
+These binaries are to be considered dev/beta releases and allow you to test
+out the very latest work being done on Pulsar before it is added to a full
+release.
+
 See below for links to the latest binaries for each OS. If you want to download
 manually or pick a binary from another fork then follow the [manual instructions](#manual-download).
 
@@ -73,12 +79,6 @@ manually or pick a binary from another fork then follow the [manual instructions
 :::
 
 ### Manual download
-
-Binaries are produced by [Cirrus CI](https://cirrus-ci.com/github/pulsar-edit/pulsar)
-for each commit to the Pulsar repository.  
-These binaries are to be considered dev/beta releases and allow you to test
-out the very latest work being done on Pulsar before it is added to a full
-release.
 
 Binaries are built from a number of different branches and PRs but you should
 stick to the **master** branch releases for the most stable ones unless you know

--- a/docs/download.md
+++ b/docs/download.md
@@ -20,6 +20,60 @@ dev/beta releases of Pulsar or [build from source](https://pulsar-edit.dev/docs/
 
 ## Cirrus CI binaries
 
+See below for links to the latest binaries for each OS. If you want to download
+manually or pick a binary from another fork then follow the [manual instructions](#manual-download).
+
+::: details Linux
+
+**x86_64** - For most desktops and laptops with Intel or AMD processors
+
+|                                    Package                                    |    Distribution    |
+| :---------------------------------------------------------------------------: | :----------------: |
+|      [deb](https://web.pulsar-edit.dev/download?os=linux&type=linux_deb)      | All distributions  |
+|      [rpm](https://web.pulsar-edit.dev/download?os=linux&type=linux_rpm)      | Debian/Ubuntu etc. |
+| [Appimage](https://web.pulsar-edit.dev/download?os=linux&type=linux_appimage) |  Fedora/RHEL etc.  |
+|    [tar.gz](https://web.pulsar-edit.dev/download?os=linux&type=linux_tar)     | All distributions  |
+
+**ARM** - For ARM based devices - Raspberry Pi, Pinebook etc.
+
+|                                      Package                                      |    Distribution    |
+| :-------------------------------------------------------------------------------: | :----------------: |
+|      [deb](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_deb)      | All distributions  |
+|      [rpm](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_rpm)      | Debian/Ubuntu etc. |
+| [Appimage](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_appimage) |  Fedora/RHEL etc.  |
+|    [tar.gz](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_tar)     | All distributions  |
+
+:::
+
+::: details macOS
+
+**Silicon** - For Apple Silicon (M1/M2) macs
+
+|                                 Package                                 |     Type      |
+| :---------------------------------------------------------------------: | :-----------: |
+| [dmg](https://web.pulsar-edit.dev/download?os=silicon_mac&type=mac_dmg) | DMG installer |
+| [zip](https://web.pulsar-edit.dev/download?os=silicon_mac&type=mac_zip) |  Zip archive  |
+
+**Intel** - For Intel macs
+
+|                                Package                                |     Type      |
+| :-------------------------------------------------------------------: | :-----------: |
+| [dmg](https://web.pulsar-edit.dev/download?os=intel_mac&type=mac_dmg) | DMG installer |
+| [zip](https://web.pulsar-edit.dev/download?os=intel_mac&type=mac_zip) |  Zip archive  |
+
+:::
+
+::: details Windows
+
+|                                   Package                                    |         Type          |
+| :--------------------------------------------------------------------------: | :-------------------: |
+|  [dmg](https://web.pulsar-edit.dev/download?os=windows&type=windows_setup)   |       Installer       |
+| [zip](https://web.pulsar-edit.dev/download?os=windows&type=windows_portable) | Portable (no install) |
+
+:::
+
+### Manual download
+
 Binaries are produced by [Cirrus CI](https://cirrus-ci.com/github/pulsar-edit/pulsar)
 for each commit to the Pulsar repository.  
 These binaries are to be considered dev/beta releases and allow you to test

--- a/docs/download.md
+++ b/docs/download.md
@@ -34,7 +34,7 @@ manually or pick a binary from another fork then follow the [manual instructions
 | [Appimage](https://web.pulsar-edit.dev/download?os=linux&type=linux_appimage) |  Fedora/RHEL etc.  |
 |    [tar.gz](https://web.pulsar-edit.dev/download?os=linux&type=linux_tar)     | All distributions  |
 
-**ARM** - For ARM based devices - Raspberry Pi, Pinebook etc.
+**ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                      Package                                      |    Distribution    |
 | :-------------------------------------------------------------------------------: | :----------------: |
@@ -65,10 +65,10 @@ manually or pick a binary from another fork then follow the [manual instructions
 
 ::: details Windows
 
-|                                   Package                                    |         Type          |
-| :--------------------------------------------------------------------------: | :-------------------: |
-|  [dmg](https://web.pulsar-edit.dev/download?os=windows&type=windows_setup)   |       Installer       |
-| [zip](https://web.pulsar-edit.dev/download?os=windows&type=windows_portable) | Portable (no install) |
+|                                      Package                                      |         Type          |
+| :-------------------------------------------------------------------------------: | :-------------------: |
+|    [Setup](https://web.pulsar-edit.dev/download?os=windows&type=windows_setup)    |       Installer       |
+| [Portable](https://web.pulsar-edit.dev/download?os=windows&type=windows_portable) | Portable (no install) |
 
 :::
 


### PR DESCRIPTION
Adds the direct Cirrus download links from https://github.com/pulsar-edit/package-frontend/pull/13

Each OS is in its own folding section which I feel is a lot more obvious for this kind of thing than using the tab switcher.

Good suggestion from [Discord](https://discord.com/channels/992103415163396136/992275353961775145/1050474080257720340) to unfold for the detected os in the agent and leave the others collapsed.

Small addition to the css because the table uses the dark background colour from the container on some lines making it quite hard to see the headers etc. I've added a temp fix to lighten the header and odd children to make it stick out. This will be redone once we settle on a theme - didn't want to start changing this more globally just yet for sake of later simplification. 