### PR TITLE
Add donation page

### DIFF
--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -52,11 +52,6 @@ const navbar_en = [
         text: "Mastodon",
         icon: 'brands fa-mastodon',
         link: "https://fosstodon.org/@pulsaredit"
-      },
-      {
-        text: "OpenCollective",
-        icon: 'solid fa-hand-holding-dollar',
-        link: "https://opencollective.com/pulsar-edit"
       }
     ]
   },

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -1,14 +1,5 @@
 const navbar_en = [
   {
-    text: "Start Here",
-    icon: 'solid fa-flag',
-    children: [
-      '/docs/launch-manual',
-      '/docs/packages/core',
-      '/docs/packages/community'
-    ]
-  },
-  {
     text: 'Download',
     icon: 'solid fa-download',
     link: '/download/'
@@ -68,6 +59,11 @@ const navbar_en = [
         link: "https://opencollective.com/pulsar-edit"
       }
     ]
+  },
+  {
+    text: "Donate",
+    icon: 'solid fa-hand-holding-dollar',
+    link: '/donate/'
   },
   {
     text: "Packages",

--- a/docs/community.md
+++ b/docs/community.md
@@ -14,7 +14,3 @@ community.
 - [<i class="fa-brands fa-discord"></i> - Discord](https://discord.gg/7aEbB9dGRT)
 - [<i class="fa-brands fa-reddit"></i> - Reddit](https://www.reddit.com/r/pulsaredit/)
 - [<i class="fa-brands fa-mastodon"></i> - Mastodon](https://fosstodon.org/@pulsaredit)
-
-If you wish to contribute to the running costs of the project we have an
-[OpenCollective](https://opencollective.com/pulsar-edit) where you can safely
-donate.

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -1,0 +1,22 @@
+---
+title: Donate to Pulsar
+path: /donate/
+sitemap:
+  priority: 0.8
+  changefreq: "weekly"
+---
+
+Pulsar will always be free and fully open to the community but we do have some
+running costs associated with hosting the package repository along with other
+expenses.
+
+If you wish to contribute to the running costs of the project we have an
+[OpenCollective](https://opencollective.com/pulsar-edit) where you can safely
+donate and view how the money is being used.
+
+<a href="https://opencollective.com/pulsar-edit/donate" target="_blank">
+  <img src="https://opencollective.com/webpack/donate/button@2x.png?color=blue" width=300 />
+</a>
+
+We are currently talking about other donation platforms that we might support so
+watch this space!

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,13 @@ lang: en-us
 title: Home
 home: true
 actions:
-  - text: "Download 💡"
+  - text: "Download 📥"
     link: "/download/"
+    type: primary
+  - text: "Documentation 📖"
+    link: "/docs/"
+  - text: "Donate 🎁"
+    link: "/donate/"
 heroText: Pulsar
 features:
   - title: "Cross-platform Editing"


### PR DESCRIPTION
This adds a donation page to the website and moves the OC link out of the community section into its own navbar item and with its own page.

This is based on advice from the recent Distrotube video to make donations more obvious without making them obnoxious.

I've also (somewhat experimentally) added a couple more "action" links to the main page
- Download has been updated with a "primary" attribute and changed the emoji (the theme colour will very likely change from green to some kind of purple so don't worry too much about the contrast of the emoji for now - also very easy to change...).
- Documentation has been added
- Donate has been added

Keen for feedback on that, currently looks like:
![image](https://user-images.githubusercontent.com/58074586/206548170-4f97c707-03c1-4ac2-8c91-1f14887e4597.png)

I've also removed the "Start here" dropdown on the navbar to make room for the donate one, it wasn't really being used, we can always re-instate it later if we need to but it only had one useful link that is really covered by just going to the documentation link and looking at the sidebar.

