### PR TITLE
Update faq with macos error

### DIFF
--- a/docs/docs/launch-manual/sections/faq/index.md
+++ b/docs/docs/launch-manual/sections/faq/index.md
@@ -13,3 +13,4 @@ inquire as to the status of this document.
 :::
 
 @include(sections/get-help.md)
+@include(sections/common-issues.md)

--- a/docs/docs/launch-manual/sections/faq/sections/common-issues.md
+++ b/docs/docs/launch-manual/sections/faq/sections/common-issues.md
@@ -1,6 +1,6 @@
 ## Common Issues
 
-### macOS error "_App Is Damaged and Can’t Be Opened_"
+### macOS error "_App is damaged and can’t be opened_"
 
 Current binaries are not signed so will produce an error "**_App is damaged and
 can’t be opened_**". This can be fixed by running

--- a/docs/docs/launch-manual/sections/faq/sections/common-issues.md
+++ b/docs/docs/launch-manual/sections/faq/sections/common-issues.md
@@ -1,0 +1,9 @@
+## Common Issues
+
+### macOS error "_App Is Damaged and Can’t Be Opened_"
+
+Current binaries are not signed so will produce an error "**_App is damaged and
+can’t be opened_**". This can be fixed by running
+`xattr -cr /Applications/Pulsar.app/` in the terminal.  
+See [here](https://appletoolbox.com/app-is-damaged-cannot-be-opened-mac/) for
+more information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,11 @@ Fedora, Snap, Flatpak, Arch/AUR etc. but we need to get to a good point with
 a stable release before we instigate that so for now the downloadable binaries
 are the main supported downloads.
 
-### Automatic Updates 
+### Automatic Updates
 
-Currently Pulsar does not support automatic updates. What this means is that new versions will have to be obtained via the Cirrus CI or Download links here on our website. This is something on our roadmap to change as soon as possible.
+Currently Pulsar does not support automatic updates. What this means is that new
+versions will have to be obtained via the Cirrus CI or Download links here on
+our website. This is something on our roadmap to change as soon as possible.
 
 ### Packages
 
@@ -75,7 +77,11 @@ or as a [GitHub issue](https://github.com/pulsar-edit/pulsar/issues/new?assignee
 
 #### Known Issues
 
-- MacOS Performance: Currently performance on MacOS isn't what we hope to achieve. Often times this can be resolved by disabling the `github` package.
+- macOS Performance: Currently performance on MacOS isn't what we hope to
+  achieve. Often times this can be resolved by disabling the `github` package.
+- macOS dmg install: Current binaries are not signed so will produce an error
+  "App is damaged and can’t be opened". This can be fixed by running
+  `xattr -cr /Applications/Pulsar.app/`.
 
 ### Logos, branding and website design
 


### PR DESCRIPTION
Common question (and likely to become more common as more people start to use it).

Provides info about how to make the macOS app work by running `xattr -cr /Applications/Pulsar.app/`.

Can be removed if and when we can sign the mac binaries.

Added to notices and FAQ as this is going to affect literally all macOS users.