### PR TITLE
Add xattrs command to macOS download section

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -36,7 +36,7 @@ manually or pick a binary from another fork then follow the [manual instructions
 |                                    Package                                    |    Distribution    |
 | :---------------------------------------------------------------------------: | :----------------: |
 |      [deb](https://web.pulsar-edit.dev/download?os=linux&type=linux_deb)      | Debian/Ubuntu etc. |
-|      [rpm](https://web.pulsar-edit.dev/download?os=linux&type=linux_rpm)      | Fedora/RHEL etc. 	 |
+|      [rpm](https://web.pulsar-edit.dev/download?os=linux&type=linux_rpm)      |  Fedora/RHEL etc.  |
 | [Appimage](https://web.pulsar-edit.dev/download?os=linux&type=linux_appimage) | All distributions  |
 |    [tar.gz](https://web.pulsar-edit.dev/download?os=linux&type=linux_tar)     | All distributions  |
 
@@ -45,13 +45,27 @@ manually or pick a binary from another fork then follow the [manual instructions
 |                                      Package                                      |    Distribution    |
 | :-------------------------------------------------------------------------------: | :----------------: |
 |      [deb](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_deb)      | Debian/Ubuntu etc. |
-|      [rpm](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_rpm)      | Fedora/RHEL etc. 	 |
+|      [rpm](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_rpm)      |  Fedora/RHEL etc.  |
 | [Appimage](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_appimage) | All distributions  |
 |    [tar.gz](https://web.pulsar-edit.dev/download?os=arm_linux&type=linux_tar)     | All distributions  |
 
 :::
 
-::: details macOS
+:::: details macOS
+
+<!--TODO: Remove once app is signed and error no longer shows-->
+
+::: info Info
+
+Current binaries are not signed so will produce an error _"App is damaged and
+can’t be opened"_.
+The following command should be run after installation.
+
+```sh
+$ xattr -cr /Applications/Pulsar.app/
+```
+
+:::
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
@@ -67,7 +81,7 @@ manually or pick a binary from another fork then follow the [manual instructions
 | [dmg](https://web.pulsar-edit.dev/download?os=intel_mac&type=mac_dmg) | DMG installer |
 | [zip](https://web.pulsar-edit.dev/download?os=intel_mac&type=mac_zip) |  Zip archive  |
 
-:::
+::::
 
 ::: details Windows
 


### PR DESCRIPTION
Discussed [here](https://discord.com/channels/992103415163396136/992103415163396139/1052042794102968320)

Adds the `xattr` command right into the download section to make it as obvious as possible until we can get the app signed. 
For reference and tracking this same info is now in three places:
- Front page notices
- FAQ
- macOS download section

(Also it looks like the commit hook took exception to the previous justification of the Linux table which it has decided to fix).