### PR TITLE
Include privacy policy

### DIFF
--- a/docs/docs/resources/privacy/index.md
+++ b/docs/docs/resources/privacy/index.md
@@ -2,7 +2,7 @@
 title: Privacy Policy
 ---
 
-::: warning Under Construction
-This document is under construction, please check back soon for updates.
-Please see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and feel free to ask for assistance or inquire as to the status of this document.
-:::
+<!--This page is generated from the PRIVACY_POLICY.md page on the org-level
+documentation at https://github.com/pulsar-edit/.github-->
+
+@include(@orgdocs/PRIVACY_POLICY.md)


### PR DESCRIPTION
Fills in the privacy policy page using content from https://github.com/pulsar-edit/.github/pull/84. Links were already in place, this just updates the content.