### PR TITLE
Add GitHub Sponsors to Donate Page, Minor Added 2023 to copyright in footer

### DIFF
--- a/docs/.vuepress/footer.js
+++ b/docs/.vuepress/footer.js
@@ -190,7 +190,7 @@ const footer =
   <hr>
 
   <div class="copyrightBar">
-    <span> Pulsar-Edit © 2022 </span>
+    <span> Pulsar-Edit © 2022-2023 </span>
   </div>`
 
 export { footer as footer };

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -18,8 +18,8 @@ donate and view how the money is being used.
   <img src="https://opencollective.com/webpack/donate/button@2x.png?color=blue" width=300 />
 </a>
 
-Additionally if you'd rather contribute to the running costs of the project via
-[GitHub Sponsors](https://github.com/sponsors/pulsar-edit) you can visit our GitHub profile to safely donate.
+If you'd rather contribute via [GitHub Sponsors](https://github.com/sponsors/pulsar-edit)
+you can do this on our GitHub profile.
 
 <iframe src="https://github.com/sponsors/pulsar-edit/card" title="Sponsor pulsar-edit" height="225" width="600" style="border: 0;"></iframe>
 

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -18,5 +18,10 @@ donate and view how the money is being used.
   <img src="https://opencollective.com/webpack/donate/button@2x.png?color=blue" width=300 />
 </a>
 
+Additionally if you'd rather contribute to the running costs of the project via
+[GitHub Sponsors](https://github.com/sponsors/pulsar-edit) you can visit our GitHub profile to safely donate.
+
+<iframe src="https://github.com/sponsors/pulsar-edit/card" title="Sponsor pulsar-edit" height="225" width="600" style="border: 0;"></iframe>
+
 We are currently talking about other donation platforms that we might support so
 watch this space!


### PR DESCRIPTION
This PR is small and simple. 

It's main purpose is to add the GitHub Sponsors as an alternative way to donate to us, for those that don't want to create an account on Open Collective or for any other reason.

Additionally I've changed our footer copyright from `2022` to `2022-2023` and thought then we could just continuously update the `23` as needed.

What this page now looks like is below:
![image](https://user-images.githubusercontent.com/26921489/212212837-0175f628-e37a-459b-9ef8-4970a177585c.png)
