### PR TITLE
Updating our Documentation around community packages

### DIFF
--- a/docs/docs/packages/community/index.md
+++ b/docs/docs/packages/community/index.md
@@ -1,3 +1,0 @@
----
-title: Community Packages
----

--- a/docs/docs/packages/index.md
+++ b/docs/docs/packages/index.md
@@ -27,4 +27,8 @@ As well, we have a record of [community packages](#community-packages) as well. 
 
 ## Community Packages
 
-- TODO: Add Documentation for Community packages, these can be straight grabs of the read-mes for these packages. With possibility of overrides
+There are currently thousands of community packages published to the Pulsar Package Registry, if you are coming from Atom you should be able to find all of your familiar packages as we have archived everything that Atom once had published.
+
+If one of your favourite packages that you had on Atom is missing feel free to [contact us](https://pulsar-edit.dev/community.html) or take a look through the [Pulsar Package Registry Administrative Actions Log](https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/Admin_Actions.md) to see if it's been officially removed.
+
+Otherwise to browse the vast collection of packages available to install on Pulsar you can open up the Pulsar Settings Package page, or browse them on the [Pulsar Package Registry Website](https://web.pulsar-edit.dev/).

--- a/docs/docs/packages/index.md
+++ b/docs/docs/packages/index.md
@@ -29,6 +29,6 @@ As well, we have a record of [community packages](#community-packages) as well. 
 
 There are currently thousands of community packages published to the Pulsar Package Registry, if you are coming from Atom you should be able to find all of your familiar packages as we have archived everything that Atom once had published.
 
-If one of your favourite packages that you had on Atom is missing feel free to [contact us](https://pulsar-edit.dev/community.html) or take a look through the [Pulsar Package Registry Administrative Actions Log](https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/Admin_Actions.md) to see if it's been officially removed.
+If one of your favorite packages that you had on Atom is missing feel free to [contact us](https://pulsar-edit.dev/community.html) or take a look through the [Pulsar Package Registry Administrative Actions Log](https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/Admin_Actions.md) to see if it's been officially removed.
 
 Otherwise to browse the vast collection of packages available to install on Pulsar you can open up the Pulsar Settings Package page, or browse them on the [Pulsar Package Registry Website](https://web.pulsar-edit.dev/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ from the huge package ecosystem
 
 Currently searching and downloading from the [package repository](https://web.pulsar-edit.dev/)
 is fully functional but other functions for maintaining packages such as
-publishing/updating/deleting are not yet functional.
+publishing/updating/deleting are in beta. Feel free to publish and update your packages, but if you experience any issues please feel free to report this to the Pulsar Team.
 
 ### Pulsar
 


### PR DESCRIPTION
I recently noticed the `TODO` left in our Community Packages documentation section was leading [some users to believe we don't support community packages](https://www.reddit.com/r/pulsaredit/comments/108iowt/questions_on_syntax_highlighting_and_how_to/) at this time.

Obviously this is false. And as we don't have plans to show community packages on this page anytime soon, I thought it'd make plenty of sense to update this document in the way that I have. By mostly pointing to our Package Viewing website, and add a note for Atom users that they very likely can find their package if needed.

Otherwise I've also updated the notice on our front page, that said the now outdated information that Publishing/Updating doesn't work.

I tried to make it obvious that this process is not yet foolproof, but should function for the most part.