### PR TITLE
Update download links for 1.101.0 release

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -18,19 +18,19 @@ additional work.
 
 |                                                                         Package                                                                         |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|            deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Linux.pulsar_1.100.0-beta_amd64.deb)            | Debian/Ubuntu etc. |
-|           rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Linux.pulsar-1.100.0-beta.x86_64.rpm)            |  Fedora/RHEL etc.  |
-| AppImage <sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Linux.Pulsar-1.100.0-beta.AppImage) | All distributions  |
-|            tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Linux.pulsar-1.100.0-beta.tar.gz)            | All distributions  |
+|            deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar_1.101.0-beta_amd64.deb)            | Debian/Ubuntu etc. |
+|           rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.x86_64.rpm)            |  Fedora/RHEL etc.  |
+| AppImage <sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.Pulsar-1.101.0-beta.AppImage) | All distributions  |
+|            tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                             Package                                                                              |    Distribution    |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/ARM.Linux.pulsar_1.100.0-beta_arm64.deb)               | Debian/Ubuntu etc. |
-|             rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/ARM.Linux.pulsar-1.100.0-beta.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| AppImage<sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/ARM.Linux.Pulsar-1.100.0-beta-arm64.AppImage) | All distributions  |
-|           tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/ARM.Linux.pulsar-1.100.0-beta-arm64.tar.gz)            | All distributions  |
+|              deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar_1.101.0-beta_arm64.deb)               | Debian/Ubuntu etc. |
+|             rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| AppImage<sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.Pulsar-1.101.0-beta-arm64.AppImage) | All distributions  |
+|           tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -55,17 +55,17 @@ $ xattr -cr /Applications/Pulsar.app/
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
-|                                                                 Package                                                                 |     Type      |
-| :-------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Silicon_Mac.Pulsar-1.100.0-beta-arm64.dmg) | DMG installer |
-|                                                          zip - Latest \| Beta                                                           |  Zip archive  |
+|                                                                 Package                                                                     |     Type      |
+| :-----------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
+| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Silicon.Mac.Pulsar-1.101.0-beta-arm64.dmg)     | DMG installer |
+| zip - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Silicon.Mac.Pulsar-1.101.0-beta-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
-|                                                             Package                                                             |     Type      |
-| :-----------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Intel.Mac.Pulsar-1.100.0-beta.dmg) | DMG installer |
-|                                                      zip - Latest \| Beta                                                       |  Zip archive  |
+|                                                             Package                                                                 |     Type      |
+| :---------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
+| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Intel.Mac.Pulsar-1.101.0-beta.dmg)     | DMG installer |
+| zip - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Intel.Mac.Pulsar-1.101.0-beta-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -83,8 +83,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                                Package                                                                |         Type          |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :-------------------: |
-| Setup - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Windows.Pulsar.Setup.1.100.0-beta.exe) |       Installer       |
-|  Portable - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.100.0-beta/Windows.Pulsar.1.100.0-beta.exe)   | Portable (no install) |
+| Setup - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Windows.Pulsar.Setup.1.101.0-beta.exe) |       Installer       |
+|  Portable - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Windows.Pulsar.1.101.0-beta.exe)   | Portable (no install) |
 
 ::::
 


### PR DESCRIPTION
Update the download links from 1.100.0 to 1.101.0 (and adds the zip binary now it can be downloaded from cirrus).