### PR TITLE
Remove `--no-sandbox` Warnings from Download Page

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -16,24 +16,23 @@ additional work.
 
 **x86_64** - For most desktops and laptops with Intel or AMD processors
 
-|                                                                         Package                                                                         |    Distribution    |
-| :-----------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|            deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar_1.101.0-beta_amd64.deb)            | Debian/Ubuntu etc. |
-|           rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.x86_64.rpm)            |  Fedora/RHEL etc.  |
-| AppImage <sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.Pulsar-1.101.0-beta.AppImage) | All distributions  |
-|            tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.tar.gz)            | All distributions  |
+|                                                                       Package                                                                        |    Distribution    |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|          deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar_1.101.0-beta_amd64.deb)           | Debian/Ubuntu etc. |
+|          rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.x86_64.rpm)          |  Fedora/RHEL etc.  |
+| AppImage <sup>[1]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.Pulsar-1.101.0-beta.AppImage) | All distributions  |
+|          tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Linux.pulsar-1.101.0-beta.tar.gz)           | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
-|                                                                             Package                                                                              |    Distribution    |
-| :--------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar_1.101.0-beta_arm64.deb)               | Debian/Ubuntu etc. |
-|             rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| AppImage<sup>[1][2]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.Pulsar-1.101.0-beta-arm64.AppImage) | All distributions  |
-|           tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta-arm64.tar.gz)            | All distributions  |
+|                                                                            Package                                                                            |    Distribution    |
+| :-----------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|             deb - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar_1.101.0-beta_arm64.deb)             | Debian/Ubuntu etc. |
+|            rpm - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta.aarch64.rpm)            |  Fedora/RHEL etc.  |
+| AppImage<sup>[1]</sup> - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.Pulsar-1.101.0-beta-arm64.AppImage) | All distributions  |
+|          tar.gz - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/ARM.Linux.pulsar-1.101.0-beta-arm64.tar.gz)          | All distributions  |
 
-[1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
-[2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
+[1] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
 
 :::
 
@@ -55,16 +54,16 @@ $ xattr -cr /Applications/Pulsar.app/
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
-|                                                                 Package                                                                     |     Type      |
+|                                                                   Package                                                                   |     Type      |
 | :-----------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Silicon.Mac.Pulsar-1.101.0-beta-arm64.dmg)     | DMG installer |
+|   dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Silicon.Mac.Pulsar-1.101.0-beta-arm64.dmg)   | DMG installer |
 | zip - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Silicon.Mac.Pulsar-1.101.0-beta-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
-|                                                             Package                                                                 |     Type      |
+|                                                               Package                                                               |     Type      |
 | :---------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-| dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Intel.Mac.Pulsar-1.101.0-beta.dmg)     | DMG installer |
+|   dmg - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Intel.Mac.Pulsar-1.101.0-beta.dmg)   | DMG installer |
 | zip - Latest \| [Beta](https://github.com/pulsar-edit/pulsar/releases/download/v1.101.0-beta/Intel.Mac.Pulsar-1.101.0-beta-mac.zip) |  Zip archive  |
 
 ::::

--- a/docs/download.md
+++ b/docs/download.md
@@ -102,24 +102,23 @@ manually or pick a binary from another fork then follow the [manual instructions
 
 **x86_64** - For most desktops and laptops with Intel or AMD processors
 
-|                                           Package                                           |    Distribution    |
-| :-----------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://download.pulsar-edit.dev/?os=linux&type=linux_deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://download.pulsar-edit.dev/?os=linux&type=linux_rpm)               |  Fedora/RHEL etc.  |
-| [Appimage](https://download.pulsar-edit.dev/?os=linux&type=linux_appimage)<sup>[1][2]</sup> | All distributions  |
-|             [tar.gz](https://download.pulsar-edit.dev/?os=linux&type=linux_tar)             | All distributions  |
+|                                         Package                                          |    Distribution    |
+| :--------------------------------------------------------------------------------------: | :----------------: |
+|             [deb](https://download.pulsar-edit.dev/?os=linux&type=linux_deb)             | Debian/Ubuntu etc. |
+|             [rpm](https://download.pulsar-edit.dev/?os=linux&type=linux_rpm)             |  Fedora/RHEL etc.  |
+| [Appimage](https://download.pulsar-edit.dev/?os=linux&type=linux_appimage)<sup>[1]</sup> | All distributions  |
+|           [tar.gz](https://download.pulsar-edit.dev/?os=linux&type=linux_tar)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
-|                                             Package                                             |    Distribution    |
-| :---------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_rpm)               |  Fedora/RHEL etc.  |
-| [Appimage](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_appimage)<sup>[1][2]</sup> | All distributions  |
-|             [tar.gz](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_tar)             | All distributions  |
+|                                           Package                                            |    Distribution    |
+| :------------------------------------------------------------------------------------------: | :----------------: |
+|             [deb](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_deb)             | Debian/Ubuntu etc. |
+|             [rpm](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_rpm)             |  Fedora/RHEL etc.  |
+| [Appimage](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_appimage)<sup>[1]</sup> | All distributions  |
+|           [tar.gz](https://download.pulsar-edit.dev/?os=arm_linux&type=linux_tar)            | All distributions  |
 
-[1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
-[2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
+[1] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
 
 :::
 


### PR DESCRIPTION
Now that this issue is fixed in our latest release, and in all of our latest Cirrus builds, I've removed the warning as it should no longer be needed.