### PR TITLE
Replace automatic kit with cloudflare CDN

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,7 +33,7 @@ export default defineUserConfig({
     displayAllHeaders: true,
     editLinks: true,
     // iconAssets: 'fontawesome',
-    iconPrefix: 'fas ',
+    iconPrefix: 'fa-',
     repo: "pulsar-edit",
     repoLabel: "GitHub",
     displayFooter: true,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,7 +32,8 @@ export default defineUserConfig({
     logoDark: "/logo-name-navbar-dark.svg",
     displayAllHeaders: true,
     editLinks: true,
-    iconAssets: "fontawesome",
+    // iconAssets: 'fontawesome',
+    iconPrefix: 'fas ',
     repo: "pulsar-edit",
     repoLabel: "GitHub",
     displayFooter: true,
@@ -83,5 +84,6 @@ export default defineUserConfig({
   }),
   head: [
     ['script', {src: '/download-preselect.js'}],
+    ['script', {src: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/js/all.min.js'}]
  ],
 });

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -11,7 +11,7 @@ const navbar_en = [
   },
   {
     text: 'Repositories',
-    icon: 'fab fa-github',
+    icon: 'brands fa-github',
     link: '/repos/'
   },
   {
@@ -40,17 +40,17 @@ const navbar_en = [
       },
       {
         text: "Discord",
-        icon: 'fab fa-discord',
+        icon: 'brands fa-discord',
         link: "https://discord.gg/7aEbB9dGRT"
       },
       {
         text: "Reddit",
-        icon: 'fab fa-reddit',
+        icon: 'brands fa-reddit',
         link: "https://www.reddit.com/r/pulsaredit/"
       },
       {
         text: "Mastodon",
-        icon: 'fab fa-mastodon',
+        icon: 'brands fa-mastodon',
         link: "https://fosstodon.org/@pulsaredit"
       }
     ]

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -11,7 +11,7 @@ const navbar_en = [
   },
   {
     text: 'Repositories',
-    icon: 'brands fa-github',
+    icon: 'fab fa-github',
     link: '/repos/'
   },
   {
@@ -40,17 +40,17 @@ const navbar_en = [
       },
       {
         text: "Discord",
-        icon: 'brands fa-discord',
+        icon: 'fab fa-discord',
         link: "https://discord.gg/7aEbB9dGRT"
       },
       {
         text: "Reddit",
-        icon: 'brands fa-reddit',
+        icon: 'fab fa-reddit',
         link: "https://www.reddit.com/r/pulsaredit/"
       },
       {
         text: "Mastodon",
-        icon: 'brands fa-mastodon',
+        icon: 'fab fa-mastodon',
         link: "https://fosstodon.org/@pulsaredit"
       }
     ]


### PR DESCRIPTION
# Summary

This PR hopes to replace the fontawesome kit imports that get automatically generated for vuepress-theme-hope and replace it with the generic cloudflare CDN with the same version of `6.2.1`.

I am not sure that this will fix the live site or not.

# Screenshots
<img width="1527" alt="Screenshot 2023-01-28 at 9 06 49 PM" src="https://user-images.githubusercontent.com/6710794/215302303-c8b82d08-6f64-428c-a905-14a82b0fef8c.png">
<img width="681" alt="Screenshot 2023-01-28 at 9 06 56 PM" src="https://user-images.githubusercontent.com/6710794/215302306-e54324f1-7943-4f3a-a408-450efc8ca6c0.png">
