### PR TITLE
Launch Manual V2 Skeleton

### DIFF
--- a/docs/docs/launch-manual-v2/index.md
+++ b/docs/docs/launch-manual-v2/index.md
@@ -8,6 +8,10 @@ Currently this page is not linked on the sidebar as it is nowhere near complete.
 
 Otherwise with that said lets get onto our docs.
 
+## [Pulsar Package Registry Frontend Website](/docs/launch-manual-v2/sections/ppr-frontend)
+
+Detials and Guides to using the Pulsar Package Registry Frontend Website, where you can manage your Pulsar User Account, and browse the available Packages for Pulsar from any device on the web.
+
 ## [Authoring Pulsar Packages](/docs/launch-manual-v2/sections/authoring-packages)
 
 Authoring Pulsar Packages will walk you through the basics of creating your Pulsar Packages and Publishing them to the Pulsar Package Registry. This is where you should go if you'd like to become one of the amazing community members to publish and maintain a package for everyone to use.

--- a/docs/docs/launch-manual-v2/index.md
+++ b/docs/docs/launch-manual-v2/index.md
@@ -1,0 +1,13 @@
+---
+title: Launch Manual v2
+---
+
+Here you will find the V2 of the Launch Manual. A redisgined and reimagined way to browse and read our documentation. With the goal of being easier than before to understand, skim, and consume.
+
+Currently this page is not linked on the sidebar as it is nowhere near complete. But if you've found the page by accident feel free to click onto the standard Launch Manual on the sidebar as the documentation there is complete.
+
+Otherwise with that said lets get onto our docs.
+
+## [Authoring Pulsar Packages](/docs/launch-manual-v2/sections/authoring-packages)
+
+Authoring Pulsar Packages will walk you through the basics of creating your Pulsar Packages and Publishing them to the Pulsar Package Registry. This is where you should go if you'd like to become one of the amazing community members to publish and maintain a package for everyone to use.

--- a/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
+++ b/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
@@ -1,0 +1,27 @@
+---
+lang: en-US
+title: Authoring Pulsar Packages
+description: Creating and Publishing Packages for Pulsar Package Registry
+---
+
+# Authoring Pulsar Packages
+
+Here we will focus on the "Hackable" part of the Hyper-Hackable Editor. As well as take a look at how to get your package listed on the Pulsar Package Registry. As we've seen and you've probably noticed a huge part of Pulsar is made up of bundled and community made packages. If you wish to add some functionality to Pulsar, you have access to the same APIs and tools that the core features of Pulsar has. From the [tree-view](https://github.com/pulsar-edit/tree-view) to the [command-palette](https://github.com/pulsar-edit/command-palette) functionality, even the most core features of Pulsar are implemented as packages.
+
+In this section we will cover how to extend the functionality of Pulsar through writing packages. This will be everything from new user interfaces to new language grammars to new themes. We'll learn this by writing a series of increasinly complex packages together, introducing you to new APIs and tools and techniques as we need them.
+
+Additionally we will then take a look at how we can get your packages published to the Pulsar Package Registry using the built in tool PPM to do so.
+
+---
+
+If you are just jumping in here are some resources you may want to keep handy to get yourself familair with the other parts of Pulsar we will be using here.
+
+- [Pulsar Package Registry API]()
+- [Pulsar Editor API]()
+- [Using PPM]()
+
+---
+
+::: details Sections
+
+:::

--- a/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
+++ b/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
@@ -24,4 +24,8 @@ If you are just jumping in here are some resources you may want to keep handy to
 
 ::: details Sections
 
+- [Publishing a Package](#publishing-a-package)
+
 :::
+
+@include(sections/publishing-a-package.md)

--- a/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
+++ b/docs/docs/launch-manual-v2/sections/authoring-packages/index.md
@@ -4,8 +4,6 @@ title: Authoring Pulsar Packages
 description: Creating and Publishing Packages for Pulsar Package Registry
 ---
 
-# Authoring Pulsar Packages
-
 Here we will focus on the "Hackable" part of the Hyper-Hackable Editor. As well as take a look at how to get your package listed on the Pulsar Package Registry. As we've seen and you've probably noticed a huge part of Pulsar is made up of bundled and community made packages. If you wish to add some functionality to Pulsar, you have access to the same APIs and tools that the core features of Pulsar has. From the [tree-view](https://github.com/pulsar-edit/tree-view) to the [command-palette](https://github.com/pulsar-edit/command-palette) functionality, even the most core features of Pulsar are implemented as packages.
 
 In this section we will cover how to extend the functionality of Pulsar through writing packages. This will be everything from new user interfaces to new language grammars to new themes. We'll learn this by writing a series of increasinly complex packages together, introducing you to new APIs and tools and techniques as we need them.

--- a/docs/docs/launch-manual-v2/sections/authoring-packages/sections/publishing-a-package.md
+++ b/docs/docs/launch-manual-v2/sections/authoring-packages/sections/publishing-a-package.md
@@ -1,0 +1,71 @@
+## Publishing a Package
+
+Pulsar bundles a command line utility called `ppm` which we first used back in [Command Line](../../../using-pulsar/#command-line) to search for and install packages via the command line. This is invoked by using the `pulsar` command with the `-p` or `--package` option. The `pulsar -p` command can also be used to publish packages to the Pulsar Package Registry and to update them.
+
+See more in the [PPM Docs]() section.
+
+### Prepare Your Package
+
+There are a few important things to double check before publishing your package:
+
+- Your `package.json` file has a `name`, `description`, and `repository` fields.
+- Your `package.json` `name` field is URL Safe, as in it doesn't include an emoji or special character.
+- Your `package.json` `version` field is [Semver V2](https://semver.org/spec/v2.0.0.html) compliant.
+- Your `package.json` `engines` field contains an entry for `atom` such as: `"enginges": { "atom": ">=1.0.0 <2.0.0"}`.
+- Your package has a `README.md` file at it's root.
+- Your `repository` URL in the `package.json` file is the same as the URL of your repository on GitHub.
+- Your package is in a git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](https://help.github.com/articles/importing-a-git-repository-using-the-command-line/) if your package isn't already on GitHub.
+
+### Publishing Your Package
+
+Before you publish a package it is a good idea to check ahead of time if a
+package with the same name has already been published to
+[the Pulsar Package Repository](https://web.pulsar-edit.dev/packages). You can
+do that by visiting `https://web.pulsar-edit.dev/packages/your-package-name` to
+see if the package already exists. If it does, update your package's name to
+something that is available before proceeding.
+
+Now let's review what the `pulsar -p publish` command does:
+
+1. Registers the package name on Pulsar Package Repository if it is being
+   published for the first time.
+2. Updates the `version` field in the `package.json` file and commits it.
+3. Creates a new [Git tag](https://git-scm.com/book/en/Git-Basics-Tagging) for
+   the version being published.
+4. Pushes the tag and current branch up to GitHub.
+5. Updates Pulsar Package Repository with the new version being published.
+
+Now run the following commands to publish your package:
+
+```sh
+$ cd path-to-your-package
+$ pulsar -p publish minor
+```
+
+If this is the first package you are publishing, the `pulsar -p publish` command may prompt you for your GitHub username and password. If you have two-factor authentication enabled, use a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) in lieu of a password. This is required for PPM to automatically manage and push tags to your package's GitHub repo and is needed only during the first time publishing. The credentials are stored securely in your [keychain](<https://en.wikipedia.org/wiki/Keychain_(software)>) once you login.
+
+Additionally if this is your first time publishing to the Pulsar Package Registry, you also need to provide PPM an API token to access your Pulsar User Account. If you don't have a Pulsar User Account already, you'll need to make one on the [Pulsar Website](https://web.pulsar-edit.dev/login). You can learn more about creating an account on the [Pulsar Website Docs](). Once you have successfully created an account copy the API token available on your user page and use `pulsar -p --login <YOUR_PULSAR_API_TOKEN>` to give PPM your API Key. Again just like your GitHub credentials this API Key is stored securely in your [keychain](<https://en.wikipedia.org/wiki/Keychain_(software)>).
+
+Now your package is published and available on the Pulsar Package Registry. Head on over to `https://web.pulsar-edit.dev/packages/your-package-name` to see your package's page.
+
+With `pulsar -p publish`, you can bump the version and publish by using
+
+```sh
+$ pulsar -p publish <version-type>
+```
+
+Where `version-type` can be `major`, `minor`, and `patch`.
+
+- **MAJOR** version when you make incompatible API changes.
+- **MINOR** version when you add functionality in a backwards compatible manner.
+- **PATCH** version when you make backwards compatible bug fixes.
+
+i.e. to bump a package from v1.**0**.0 to v1.**1**.0:
+
+```sh
+$ pulsar -p publish minor
+```
+
+Check out [semantic versioning](https://semver.org/) to learn more about best practices for versioning your package releases.
+
+You can also run `pulsar -p help publish` to see all the available options and `pulsar -p help` to see all the other available commands. Or check our the [PPM Docs]() to learn more about using PPM.

--- a/docs/docs/launch-manual-v2/sections/ppr-frontend/index.md
+++ b/docs/docs/launch-manual-v2/sections/ppr-frontend/index.md
@@ -1,0 +1,21 @@
+---
+lang: en-US
+title: Pulsar Package Registry Frontend Website
+description: Using and Navigating the Pulsar Package Registry Website
+---
+
+# Pulsar Package Registry Frontend Website
+
+The Package Registry Frontend Website viewable on [https://web.pulsar-edit.dev](https://web.pulsar-edit.dev/) is the frontend counterpart to the Pulsar Package Registry. Allowing an easy way for anyone on any platform to view and browse the packages that are available to install on Pulsar.
+
+While the website isn't much more than a wrapper around the actual Pulsar Package Registry API it does serve a few important purposes for Pulsar.
+
+::: details Sections
+
+- [Pulsar User Account](#pulsar-user-account)
+
+:::
+
+@include(sections/pulsar-user-account.md)
+
+<!-- Social Cards, Download Link, Themes -->

--- a/docs/docs/launch-manual-v2/sections/ppr-frontend/sections/pulsar-user-account.md
+++ b/docs/docs/launch-manual-v2/sections/ppr-frontend/sections/pulsar-user-account.md
@@ -1,0 +1,71 @@
+## Pulsar User Account
+
+A Pulsar User Account enables you to Publish and manage Published Packages to the Pulsar Package Registry, as well as lets you star packages that exist on the Pulsar Package Registry.
+
+Otherwise for just downloading and using packages from the Pulsar Package Registry no account is required.
+
+### Creating a Pulsar User Account
+
+To create a Pulsar User Account you just need to navigate to the Pulsar Package Registry Website and click "Sign In" on the top header bar.
+Otherwise you can go directly to [the Signup Page](https://web.pulsar-edit.dev/login).
+
+Here you can see there's a few choices of how to create your account.
+
+- [Sign Up with a PAT Token](#sign-up-with-a-pat-token)
+- [Sign Up with GitHub OAuth](#sign-up-with-github-oauth)
+
+#### Sign Up with a PAT Token
+
+Using a PAT token from GitHub allows you precise control over what permissions your Pulsar User Account has over your GitHub account, which you don't get with the OAuth Signup.
+
+This way you can go to your GitHub Account and [create your own PAT token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) that is create a Personal Access Token with only the permissions you decide.
+
+When creating your PAT token it's good to know what scopes should be allowed access to your Pulsar User Account. By default the only scopes needed are:
+
+- public_repo
+- read:org
+
+Beyond that your Pulsar User Account won't try to use any additional permissions.
+
+Once your PAT Token is created navigate back to the Pulsar Signup Screen and plug your PAT token into the text box where it says "Enter your GitHub PAT" and click "Sign Up". After a few redirects you should be brought to your [Pulsar User Account Page](https://web.pulsar-edit.dev/users).
+
+#### Sign Up with GitHub OAuth
+
+Using GitHub OAuth signup means you don't have to manage the permissions and signup process on your own as opposed to the PAT Token signup.
+
+Still when signing up with GitHub OAuth the only permissions requested (That you'll be able to review during the process) are:
+
+- public_repo
+- read:org
+
+These are the only permissions needed for your Pulsar User Account to access all features it's capable of.
+
+Once you click to "Sign Up with GitHub OAuth" you'll be redirected to GitHub to authorize Pulsar to access your account. There you can check the account you are allowing access, and review the permissions being granted.
+
+Afterwards you should be redirected to your [Pulsar User Account Page](https://web.pulsar-edit.dev/users).
+
+#### Managing your Account
+
+Now that your Pulsar User Account has been successfully created you can manage it on your [Pulsar User Account Page](https://web.pulsar-edit.dev/users).
+
+Here you can view the account information saved to Pulsar, and view your Pulsar API Token.
+
+This Pulsar API Token is what can be used to allow you to publish to the Pulsar Package Registry using [PPM]().
+
+Otherwise if you ever notice your account information here has become out of date (i.e. you've changed your profile picture) you can always click "Log Out" at the top of the page, and sign in again with the same steps as before. When you click go through the sign up process after already having created a Pulsar User Account this just updates your account information with what's most recent from GitHub.
+
+#### Notes on a Pulsar User Account
+
+A few important notes about your Pulsar User Account to keep in mind.
+
+Pulsar greatly respects your privacy, and more than that doesn't want the chance to invade your privacy, or be responsible for your sensitive account credentials.
+
+That's why when you create a User Account with Pulsar there are only three pieces of information stored about you:
+
+- Your GitHub Account Username.
+- Your GitHub Gravatar Image URL.
+- Your GitHub `node_id`.
+
+Think of your `node_id` like the random number GitHub assigned to your account when you created it. This is a public value that anyone on GitHub can find using the API and doesn't reveal any private details about yourself , your location or your account. Beyond this the Pulsar Backend collects zero information about who you are, and doesn't even save your API Keys itself.
+
+If you'd like to read more about how your information is used for Pulsar take a look at our [Privacy Policy]() or the [Pulsar Backend]() Documentation.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   vuepress-theme-hope: 2.0.0-beta.106
 
 dependencies:
-  .github: github.com/pulsar-edit/.github/be58e3e9aa5243419278b508da531db52bd67258
+  .github: github.com/pulsar-edit/.github/971cb20aa1a7039e73d399ceaf9eb8a6d3bc4971
   pulsar-assets: github.com/pulsar-edit/pulsar-assets/8fb8c787c296b789d5eea8dd65ea20c7a2af759d
   vuepress-theme-hope: 2.0.0-beta.106
 
@@ -7072,8 +7072,8 @@ packages:
     resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
     dev: true
 
-  github.com/pulsar-edit/.github/be58e3e9aa5243419278b508da531db52bd67258:
-    resolution: {tarball: https://codeload.github.com/pulsar-edit/.github/tar.gz/be58e3e9aa5243419278b508da531db52bd67258}
+  github.com/pulsar-edit/.github/971cb20aa1a7039e73d399ceaf9eb8a6d3bc4971:
+    resolution: {tarball: https://codeload.github.com/pulsar-edit/.github/tar.gz/971cb20aa1a7039e73d399ceaf9eb8a6d3bc4971}
     name: .github
     version: 0.0.0
     dev: false


### PR DESCRIPTION
While this PR is nowhere near completing the docs, it does have complete sections giving a general layout of the new documentation format.

Essentially here I've followed the ideas from our [Discussions](https://github.com/orgs/pulsar-edit/discussions/104) and started laying out the docs like I suggested there, additionally I've added some sections for some of the tooling on Pulsar.

The way I envision this be further layed out would be the largest section of Launch Manual then having many subsections. Which in this PR includes

* Pulsar Package Registry Frontend Website
* Authoring Packages

Then each section is able to go into as much detail as needed for that topic. But allows users to easily find what they need to know. The first section here is just about the website itself, and I'd like to see us do this for more of our big ticket items that we use, such as one for PPM, one for Pulsar that could contain just the generic usage of the editor, we could even include ones for some of our bigger or more complicated packages, teletype, and so on.

In this section these would all be user facing documents, not getting into the programming details but just general usage details.

Additionally though we are discussing on Discord how we could include more documentation from specific repos onto the site for developers.

But this is just a start to make sure we like the new layout and see what we can do.

Also to note, this PR purposefully doesn't link to this section of the docs anywhere, as they are so far from complete it'd just be confusing to users to list it publicly at this point. Although this PR would still allow you to navigate by URL to the docs.