### PR TITLE
remove/edit some more signing notices

### DIFF
--- a/docs/docs/launch-manual/sections/faq/sections/common-issues.md
+++ b/docs/docs/launch-manual/sections/faq/sections/common-issues.md
@@ -2,9 +2,10 @@
 
 ### macOS error "_App is damaged and can’t be opened_"
 
-Current binaries are not signed so will produce an error "**_App is damaged and
-can’t be opened_**". This can be fixed by running
-`xattr -cr /Applications/Pulsar.app/` in the terminal.  
+The binary is likely from before macOS binaries started being signed.
+A up-to-date and signed binary may be downloaded from [the download page](/download.html).
+The unsigned binary can be made to run by running
+`xattr -cr /Applications/Pulsar.app/` in the terminal.
 See [here](https://appletoolbox.com/app-is-damaged-cannot-be-opened-mac/) for
 more information.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,9 +79,6 @@ or as a [GitHub issue](https://github.com/pulsar-edit/pulsar/issues/new?assignee
 
 - macOS Performance: Currently performance on MacOS isn't what we hope to
   achieve. Often times this can be resolved by disabling the `github` package.
-- macOS dmg install: Current binaries are not signed so will produce an error
-  "App is damaged and can’t be opened". This can be fixed by running
-  `xattr -cr /Applications/Pulsar.app/`.
 
 ### Logos, branding and website design
 


### PR DESCRIPTION
I found some more instances of macOS unsigned notices. I changed the one in the FAQ to first point to downloads, then still provides the command. The notice under "known issues" on the home page has been removed as it is no long an issue for up to date binaries.