### PR TITLE
Add an infobox to downloads, mentioning Rolling and Regular

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -8,7 +8,7 @@ sitemap:
 
 ::: info "Rolling" and "Regular" Releases
 
-We have ["Rolling"](#rolling-release) and ["Regular"](#regular-releases) releases to choose from. These differ only in the frequency of updates they receive. (See details below.) Please use whichever suits your preference.
+We have ["Rolling"](#rolling-release) and ["Regular"](#regular-releases) releases to choose from. These differ only in the frequency of updates they receive.
 
 Note: There are no automatic updates at this time, regardless of which type of download you choose.
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -6,6 +6,14 @@ sitemap:
   changefreq: "daily"
 ---
 
+::: info "Rolling" and "Regular" Releases
+
+We have "Rolling" and "Regular" releases to choose from. These differ only in the frequency of updates they receive. (See details below.) Please use whichever suits your preference.
+
+Note: There are no automatic updates at this time, regardless of which type of download you choose.
+
+:::
+
 ## Rolling Release
 
 These releases are built on each push to our `master` branch and automatically

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,7 +8,7 @@ sitemap:
 
 ::: info "Rolling" and "Regular" Releases
 
-We have "Rolling" and "Regular" releases to choose from. These differ only in the frequency of updates they receive. (See details below.) Please use whichever suits your preference.
+We have ["Rolling"](#rolling-release) and ["Regular"](#regular-releases) releases to choose from. These differ only in the frequency of updates they receive. (See details below.) Please use whichever suits your preference.
 
 Note: There are no automatic updates at this time, regardless of which type of download you choose.
 


### PR DESCRIPTION
Informs users of multiple download options, without them having to scroll first to see them, or to know ahead of time due to reading an announcement or discussion on the Discord, etc. -- without prior knowledge or the foresight to scroll a ways down the page to check.

---

Thoughts:

I thought I'd add this, since with my "new visitor goggles" on, I think I wouldn't necessarily notice or know to look for the "Regular" releases down below. (And admittedly I think the notion of a "Rolling" release is for some adventurous souls in most projects, and it'll be reassuring for folks who feel otherwise to be able to access more Regular/"stable-as-in-fewer-updates" releases.)

Feel free to suggest improvements to the wording, or to overall give feedback on this. I just wanted to draft something up rather than get too hypothetical about it. This can be a first or final draft, we can choose not to add this, etc. Let me know your thoughts. Thank you!