### PR TITLE
[BLOG] Add v1.102.0 release post

### DIFF
--- a/docs/blog/20230215-Daeraxa-v1.102.0.md
+++ b/docs/blog/20230215-Daeraxa-v1.102.0.md
@@ -1,5 +1,5 @@
 ---
-title: The next Pulsar Release 1.102.0!
+title: New Regular Release (v1.102.0)
 author: Daeraxa
 date: 2023-02-15
 category:

--- a/docs/blog/20230215-Daeraxa-v1.102.0.md
+++ b/docs/blog/20230215-Daeraxa-v1.102.0.md
@@ -8,7 +8,7 @@ tag:
   - release
 ---
 
-Check out our newest Regular Release for Pulsar! [Available Now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.100.0-beta)
+Check out our newest Regular Release for Pulsar! [Available Now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.102.0)
 
 <!-- more -->
 

--- a/docs/blog/20230215-Daeraxa-v1.102.0.md
+++ b/docs/blog/20230215-Daeraxa-v1.102.0.md
@@ -1,0 +1,87 @@
+---
+title: The next Pulsar Release 1.102.0!
+author: Daeraxa
+date: 2023-02-15
+category:
+  - dev
+tag:
+  - release
+---
+
+Check out our newest Regular Release for Pulsar! [Available Now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.100.0-beta)
+
+<!-- more -->
+
+# The next Pulsar Release 1.102.0!
+
+With the release of Pulsar 1.102.0 we have packed it full of improvements!
+
+With a huge focus on testing this time around we hope that this will result in a more stable and functional editor in all future releases.
+
+We've also added new icons for macOS and updated many of Pulsar and core packages dependencies.
+
+But for the big news, our macOS releases are now signed! Meaning no fancy commands need to be run prior to installation and you get a guarantee that Pulsar is made and published by us. Also as you might've noticed, this version has no `beta` in its name. We are now adopting a Rolling Release model and this can be considered the first of many stable releases. Take a look at our website for more information!
+
+And again, special thank you to all of our wonderful community members that have helped us write code, log issues, respond to everyone, and donate to the project. We truly could not do this without each and every one of you.
+
+And as always, happy coding, see you among the stars!
+
+- The Pulsar Team
+
+---
+
+- Fixed a bug where `pulsar` on Windows could never trigger
+- Fixed `github` package shelling out to `git` on macOS
+- Fixed minor bugs found during fixes to tests
+- Improved our testing infastructure to aide in finding and fixing further bugs
+- Updated many dependencies of Pulsar and its core packages
+- New Pulsar Icon on macOS
+- Selected text is styled by default
+- Restored `right-clicked` CSS class on tags
+- Fixed syntax highlighting on C++
+- Updated JavaScript snippets to modern ES6 syntax
+- PPM no longer assumes `master` for git branches
+
+### Pulsar
+
+- Added: implement signing and notarizing for macOS, PR [#4](https://github.com/pulsar-edit/pulsar/pull/4) lol [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/387)
+- Fixed: Pin `python` brew installation to `3.10` during MacOS Intel Cirrus Build [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/384)
+- Update: Bump `ppm` to `a46537c0b7f0eaaef5404ef88003951fdc988c65` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/383)
+- Added: Add new macOS icon [@mdibella-dev](https://github.com/pulsar-edit/pulsar/pull/372)
+- Fixed: type $ as # [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/378)
+- Update: deps: Update github to v0.36.14-pretranspiled-take-2 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/375)
+- Added: add style to selected text by default [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/238)
+- Added: Set Max Concurrent Package Tests [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/376)
+- Fixed: c++ fixes [@icecream17](https://github.com/pulsar-edit/pulsar/pull/369)
+- Update: deps: Update github to v0.36.14-pretranspiled [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/373)
+- Update `coffeescript` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/361)
+- Updated: Misc Dependency Updates [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/362)
+- Added: Bundle `autocomplete-plus` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/358)
+- Fixed: Add LICENSE.md to extra resources (resourcesPath) [@Daeraxa](https://github.com/pulsar-edit/pulsar/pull/354)
+- Fixed: Get Windows `pulsar` Working [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/340)
+- Fixed: Restore `right-clicked` class on a right-clicked tab [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/368)
+- Updated: ppm: Update submodule to commit 4645ba2905747897b0 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/371)
+- Added: Machine decaf tabs spec [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/367)
+- Added: Manually Decaf `tabs` package Specs [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/357)
+- Fixed: Uncomment and fix a settings-view package test [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/366)
+- Added: Decaf Changes from Manual and Machine Decaf to Main [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/356)
+- Added: Manual decafe tabs [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/352)
+- Added: Organize failing tests [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/307)
+- Fixed: autocomplete-snippets: Fix repo URL [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/341)
+- Updated: update apm message to pulsar -p [@Daeraxa](https://github.com/pulsar-edit/pulsar/pull/337)
+- Fixed: Replace incorrect spellings of 'macOS' with the correct one [@mdibella-dev](https://github.com/pulsar-edit/pulsar/pull/336)
+- Changed: use `let` and `const` in js snippets [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/326)
+- Fixed: Fix URI to correct address [@mdibella-dev](https://github.com/pulsar-edit/pulsar/pull/335)
+- Updated: update copyright year (2023) [@icecream17](https://github.com/pulsar-edit/pulsar/pull/332)
+
+### ppm
+
+- Fixed: fix: Don't assume `master` when checking git packages for upgrades [@savetheclocktower](https://github.com/pulsar-edit/ppm/pull/56)
+- Fixed: meta: Normalize package.json and lockfile line endings [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/54)
+- Update: spec: Fixtures Node v10.20.1 --> Electron v12.2.3 [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/52)
+- Fixed: Fix .com links, pulsar rebranding and rebranding readme [@Daeraxa](https://github.com/pulsar-edit/ppm/pull/48)
+
+### github
+
+- Fixed: lib: Rebrand getAtomAppName() function (fix shelling out to `git` on macOS) [@DeeDeeG](https://github.com/pulsar-edit/github/pull/13)
+- Fixed: meta: Revert "main" to "./lib/index", no dist (fix package on `master` branch) [@DeeDeeG](https://github.com/pulsar-edit/github/pull/12)


### PR DESCRIPTION
I think this got forgotten in the excitement. This just adds the release note for v1.102.0 as a blog post like we have done in the past (copied from the GH release note). 