### PR TITLE
[BLOG] Adds a post with a link to "How did you hear about us" survey

### DIFF
--- a/docs/blog/20230227-Daeraxa-Survey1.md
+++ b/docs/blog/20230227-Daeraxa-Survey1.md
@@ -1,0 +1,26 @@
+---
+title: "Survey: How did you hear about us?"
+author: Daeraxa
+date: 2023-02-27
+category:
+  - survey
+tag:
+  - community
+  - socials
+---
+
+A short survey asking how you heard about the Pulsar project as well as feedback
+on our community and social presence.
+
+<!-- more -->
+
+We are curious to see where people are finding out about the project and also
+where people are looking for news, updates and information.
+
+If this goes well we may look at doing further community surveys on other
+aspects of Pulsar.
+
+There is no need to sign into any account to respond to this survey and no
+personal data is being collected (emails, names etc.).
+
+[You can find the Survey (Google Forms) here](https://docs.google.com/forms/d/e/1FAIpQLScxbP1gkvjOJ3JkdSiQm5AvBg2tqpnXZO3GxW0J6cDRlV6PJw/viewform?usp=sf_link).


### PR DESCRIPTION
I have created a survey on google forms (which should also be considered for review as part of the PR so please check out the link and have a look - feel free to submit responses if you wish as I can delete them before we publish) asking for details about how people heard about the project, where they look for updates and what we could be doing better on our social media/community updates.

Survey link: https://docs.google.com/forms/d/e/1FAIpQLScxbP1gkvjOJ3JkdSiQm5AvBg2tqpnXZO3GxW0J6cDRlV6PJw/viewform?usp=sf_link

The survey collects no personal info (unless people submit it somehow) and there is no need to log into any account.

![image](https://user-images.githubusercontent.com/58074586/221460401-bf7f7e69-fe40-46ad-8b1d-2c5f097d8522.png)

I'll review any data before publishing it, even to team members, to make sure no personal or "unsavoury" data is in there and it will be redacted if necessary.

When merged this should be published to the normal channels:
- Discord announcement
- GHD post
- Toot
- Reddit post

I can do all but one so @kaosine could you be ready on the toot if you could be so kind? We don't need a co-ordinated posting, just so long as they are vaguely near each other as I expect this will be open for a while to get a decent number of responses.

