### PR TITLE
Change theme colour to purple

### DIFF
--- a/docs/.vuepress/styles/palette.scss
+++ b/docs/.vuepress/styles/palette.scss
@@ -46,3 +46,4 @@ Layout Config
 
 
 $font-family-fancy: 'Jura, sans-serif';
+$theme-color: #ae88e5;


### PR DESCRIPTION
Current theme colour (default theme green) is a bit jarring, especially with the purple home page. The original plan was to wait for the branding and do this in one go but that seems to be taking a while.

This is really just a "one size fits all" temporary fix, just one css value which affects a bunch of stuff such as the footer, the hero text, mouseover accents, hyperlinks etc.

This purple is the same one from the package Dracula theme (`#ae88e5`). Suggestions welcome as this is very easy to change - for example I can see objection to how it looks on the light theme, maybe this should be darkened a tad?

![image](https://user-images.githubusercontent.com/58074586/222024015-848678b8-3f10-4827-9237-b5daf19f9cbd.png)
![image](https://user-images.githubusercontent.com/58074586/222024097-e4b4dcef-e45d-4310-850a-e2a2736ce559.png)
![image](https://user-images.githubusercontent.com/58074586/222024145-3b31c127-b99a-4fd9-a199-0cac8a414828.png)
![image](https://user-images.githubusercontent.com/58074586/222024186-ef0f36d1-d5da-42aa-9663-5681d4d3c346.png)
![image](https://user-images.githubusercontent.com/58074586/222024244-4c83a473-e003-43a9-a56c-e78c89181e1e.png)
