### PR TITLE
Add 1.103.0 release blog post and update site links

### DIFF
--- a/docs/blog/20230315-Daeraxa-v1.103.0.md
+++ b/docs/blog/20230315-Daeraxa-v1.103.0.md
@@ -1,0 +1,72 @@
+---
+title: It's that time again, Pulsar 1.103.0 is available now!
+author: Daeraxa
+date: 2023-03-15
+category:
+  - dev
+tag:
+  - release
+---
+
+Check out our newest Regular Release for Pulsar! [Available Now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.103.0)
+
+<!-- more -->
+
+# What is new in 1.103.0?
+
+With this release, we have a number of quality-of-life updates to make things just that little bit easier.
+
+One big change is a new settings search page! No longer will you have to trawl through the settings and packages to find that one pesky bit of config, now everything is just a few keystrokes away! This feature is still experimental and will have more updates and tweaks coming, but please feel free to [provide feedback](https://github.com/orgs/pulsar-edit/discussions/150) so we can continue to improve it.
+
+We have some updates to our snippets, autocomplete-css, and github packages, which you can read about in the change log, that bring about a whole host of improvements from updated UI to new functionality to really improve your coding experience!
+
+Of course, no update would be complete without a massive thank you to our wonderful community, especially our contributors and donors who are making all this possible.
+
+And as ever, happy coding. See you among the stars!
+
+- The Pulsar Team
+
+---
+
+- Added a new feature to Search for Pulsar's settings
+- Updated the completions provided by `autocomplete-css` to be as bleeding edge as possible.
+- Updated the instructions and look of the login flow for the `github` package.
+- Snippet transformations no longer have an implied global flag, bringing them into compatibility with snippets in most other editors.
+- Snippets can now be given command names instead of tab triggers, and thus can now be assigned to key shortcuts in `keymap.cson`.
+
+### Pulsar
+
+- Added: feature: Implement Search Settings Ability [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/416)
+- Added: Show Settings Icon in Status Bar [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/421)
+- Added: Add Automated updated of `autocomplete-css` `completions.json` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/398)
+- Bumped: ppm: Update submodule to 9af239277180f2a9ee9e86714 [@Spiker985](https://github.com/pulsar-edit/pulsar/pull/403)
+- Bumped: ppm: Update submodule to 915cbf6e5f9ea1141ef5dcaf8 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/418)
+- Bumped: deps: Bump github to v0.36.15-pretranspiled [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/415)
+- Added: actually cache based on sha [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/412)
+- Bumped: Bump `snippets` to bb00f9 [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/408)
+- Added: \[skip-ci\] Small Readme Touchup [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/404)
+- Added: json language - add .har extension [@wesinator](https://github.com/pulsar-edit/pulsar/pull/396)
+- Added: Bundle `markdown-preview`, `styleguide`, `wrap-guide` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/374)
+- Added: Add GitHub Token to Doc CI [@Spiker985](https://github.com/pulsar-edit/pulsar/pull/400)
+- Added: Add Setup Node to Package Tests [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/399)
+- Added: feat: add dev.pulsar\_edit.Pulsar.metainfo.xml [@cat-master21](https://github.com/pulsar-edit/pulsar/pull/380)
+
+### Snippets
+
+- Added: Add `command` property that registers a command name for a snippet [@savetheclocktower](https://github.com/pulsar-edit/snippets/pull/10)
+- Removed: Remove implicit `g` flag from snippet transformations [@savetheclocktower](https://github.com/pulsar-edit/snippets/pull/7)
+- Fixed: Fix failing specs [@mauricioszabo](https://github.com/pulsar-edit/snippets/pull/6)
+- Added: cleanup and rename [@Sertonix](https://github.com/pulsar-edit/snippets/pull/5)
+
+### Github
+
+- Added: rebrand git-tab-view [@icecream17](https://github.com/pulsar-edit/github/pull/17)
+- Added: lib: Update login instructions for PATs, not OAuth [@DeeDeeG](https://github.com/pulsar-edit/github/pull/15)
+
+### PPM
+
+- Fixed: src: Update default Pulsar install paths [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/49)
+- Bumped: deps: Upgrade npm to 6.14.18 [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/53)
+- Fixed: Fix installing with yarn on Windows [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/58)
+- Fixed: Fix inability to notice newer versions of git-installed packages [@savetheclocktower](https://github.com/pulsar-edit/ppm/pull/59)
+- Added: meta: Actually sync yarn.lock [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/60)

--- a/docs/download.md
+++ b/docs/download.md
@@ -108,19 +108,19 @@ those instead.
 
 |                                                       Package                                                        |    Distribution    |
 | :------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Linux.1.102.0.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Linux.1.102.0.rpm)               |  Fedora/RHEL etc.  |
-| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Linux.1.102.0.AppImage) | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Linux.1.102.0.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar_1.103.0_amd64.deb)               | Debian/Ubuntu etc. |
+|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.x86_64.rpm)               |  Fedora/RHEL etc.  |
+| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.Pulsar-1.103.0.AppImage) | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                         Package                                                          |    Distribution    |
 | :----------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/ARM.Linux.1.102.0.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/ARM.Linux.1.102.0.rpm)               |  Fedora/RHEL etc.  |
-| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/ARM.Linux.1.102.0.AppImage) | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/ARM.Linux.1.102.0.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar_1.103.0_arm64.deb)               | Debian/Ubuntu etc. |
+|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0.aarch64.rpm)               |  Fedora/RHEL etc.  |
+| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.Pulsar-1.103.0-arm64.AppImage) | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -133,15 +133,15 @@ those instead.
 
 |                                             Package                                             |     Type      |
 | :---------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Silicon.Mac.1.102.0.dmg) | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Silicon.Mac.1.102.0.zip) |  Zip archive  |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64.dmg) | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                            Package                                            |     Type      |
 | :-------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Intel.Mac.1.102.0.dmg) | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Intel.Mac.1.102.0.zip) |  Zip archive  |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0.dmg) | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -159,8 +159,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                               Package                                               |         Type          |
 | :-------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Windows.Setup.1.102.0.exe) |       Installer       |
-|  [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.102.0/Windows.1.102.0.exe)   | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.Setup.1.103.0.exe) |       Installer       |
+|  [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.1.103.0.exe)   | Portable (no install) |
 
 ::::
 


### PR DESCRIPTION
Adds the content from the GH release post for 1.103.0 and update the regular release links from 1.102.0