### PR TITLE
Add Chocolately download section

### DIFF
--- a/docs/docs/launch-manual/sections/getting-started/sections/installing-pulsar.md
+++ b/docs/docs/launch-manual/sections/getting-started/sections/installing-pulsar.md
@@ -84,6 +84,9 @@ folder.
 Pulsar is available as a 64-bit Windows installer and [portable app](https://en.wikipedia.org/wiki/Portable_application)
 that can be downloaded from [Pulsar Downloads](/download.html).
 
+We also have Pulsar available in certain package manager repositories. See the
+relevant section within the downloads for the installation commands.
+
 ![Pulsar on Windows](@images/atom/windows-system-settings.png)
 
 The context menu `Open with Pulsar` in File Explorer, and the option to
@@ -105,6 +108,9 @@ vulnerabilities you will want to update your version of Pulsar as soon as possib
 Currently Pulsar does not support automatic updates. What this means is that new
 versions will have to be obtained via the [Pulsar Downloads](/download.html) here on
 our website. This is something on our roadmap to change as soon as possible.
+
+If you have installed Pulsar via a package manager then you should use the
+instructions provided by that package manager for updating your installation.
 
 <!--TODO: Auto upgrade instructions - selectively pull info from atom archive as this becomes possible-->
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -78,6 +78,9 @@ manually or pick a binary from another branch or PR, then follow the [manual ins
 
 ::: info Info
 
+We currently have no Rolling Releases for Windows package managers - see
+[Regular Releases](#regular-releases) for these instead.
+
 Current binaries are not signed so will produce an error with Windows
 Smartscreen "Windows protected your PC"...
 You can bypass this by clicking "More info" then "Run anyway".
@@ -106,19 +109,19 @@ those instead.
 
 **x86_64** - For most desktops and laptops with Intel or AMD processors
 
-|                                                       Package                                                        |    Distribution    |
-| :------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar_1.103.0_amd64.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.x86_64.rpm)               |  Fedora/RHEL etc.  |
+|                                                           Package                                                           |    Distribution    |
+| :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar_1.103.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
 | [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.Pulsar-1.103.0.AppImage) | All distributions  |
 |           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
-|                                                         Package                                                          |    Distribution    |
-| :----------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|                                                                Package                                                                |    Distribution    |
+| :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
 |              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar_1.103.0_arm64.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0.aarch64.rpm)               |  Fedora/RHEL etc.  |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
 | [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.Pulsar-1.103.0-arm64.AppImage) | All distributions  |
 |           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0-arm64.tar.gz)            | All distributions  |
 
@@ -131,16 +134,16 @@ those instead.
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
-|                                             Package                                             |     Type      |
-| :---------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64.dmg) | DMG installer |
+|                                                     Package                                                      |     Type      |
+| :--------------------------------------------------------------------------------------------------------------: | :-----------: |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64.dmg)   | DMG installer |
 | [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
-|                                            Package                                            |     Type      |
-| :-------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0.dmg) | DMG installer |
+|                                                 Package                                                  |     Type      |
+| :------------------------------------------------------------------------------------------------------: | :-----------: |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0.dmg)   | DMG installer |
 | [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0-mac.zip) |  Zip archive  |
 
 ::::
@@ -157,10 +160,14 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 :::
 
-|                                               Package                                               |         Type          |
-| :-------------------------------------------------------------------------------------------------: | :-------------------: |
+|                                                  Package                                                   |         Type          |
+| :--------------------------------------------------------------------------------------------------------: | :-------------------: |
 | [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.Setup.1.103.0.exe) |       Installer       |
 |  [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.1.103.0.exe)   | Portable (no install) |
+
+|                            Package Manager                             |        Command         |
+| :--------------------------------------------------------------------: | :--------------------: |
+| [Chocolatey](https://community.chocolatey.org/packages/pulsar/1.103.0) | `choco install pulsar` |
 
 ::::
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -167,7 +167,7 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                            Package Manager                             |        Command         |
 | :--------------------------------------------------------------------: | :--------------------: |
-| [Chocolatey](https://community.chocolatey.org/packages/pulsar/1.103.0) | `choco install pulsar` |
+| [Chocolatey](https://community.chocolatey.org/packages/pulsar) | `choco install pulsar` |
 
 ::::
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -165,8 +165,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 | [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.Setup.1.103.0.exe) |       Installer       |
 |  [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.1.103.0.exe)   | Portable (no install) |
 
-|                            Package Manager                             |        Command         |
-| :--------------------------------------------------------------------: | :--------------------: |
+|                        Package Manager                         |        Command         |
+| :------------------------------------------------------------: | :--------------------: |
 | [Chocolatey](https://community.chocolatey.org/packages/pulsar) | `choco install pulsar` |
 
 ::::


### PR DESCRIPTION
This adds a section to the Windows regular release for Chocolatey (https://community.chocolatey.org/packages/pulsar/1.103.0).
It also slightly updates our installation and updating documentation to cover finding and updating via package manager in a non-specific way.

I've also added a note to the windows rolling release section to indicate that a package manager version is available but only via the regular release.

This is marked as a draft as this should not be merged until the package has been validated in the chocolatey repos but feel free to comment and make suggestions as if it was a final PR.