### PR TITLE
Add 1.104.0 release post, update download links + add version info to download page

### DIFF
--- a/docs/blog/20230418-Daeraxa-v1.104.0.md
+++ b/docs/blog/20230418-Daeraxa-v1.104.0.md
@@ -1,0 +1,86 @@
+---
+title: Get Ready for another fantastically essential release, Pulsar 1.104.0 is now available!
+author: Daeraxa
+date: 2023-04-15
+category:
+  - dev
+tag:
+  - release
+---
+
+Check out our newest Regular Release for Pulsar! [Available Now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0)
+
+<!-- more -->
+
+# What is new in 1.104.0?
+
+This release contains many internal changes and upgrades, focusing on preparing the editor for much bigger changes to come.
+
+One technical change is that we have internally patched WebComponents (document.registerElement), which will potentially fix many of our community packages that rely on this (deprecated) functionality.
+
+We've also started our first migrations to WASM based packages (which is required for new NodeJS Versions). Any issues found here will be important to address, in order to ensure future updates go smoothly, and to unblock the road to compatibility with newer Electron versions. Please let us know if you find anything broken due to these updates!
+
+We also have updates such as improved whitespace in a certain PHP snippet, and bleeding edge HTML completions. And with more decaf work, we should be seeing some slightly faster startup speeds.
+
+Last but not least, we can expect to see this release being available on Chocolatey for Windows; Thank you HighHarmonics, il_mix, and COLAMAroro!
+
+But as always we want to say a huge thanks to all those that contribute and donate to Pulsar, making it possible for us to continually release these improvements. And we want to give a special thanks to the new faces we are seeing in this update, with some brand new contributors!
+
+As always we appreciate every single one of you, happy coding, and see you among the stars!
+
+- The Pulsar Team
+
+---
+
+- The settings-view package now lists a package’s snippets more accurately
+- Fixed some issues with some packages with WebComponents v0 (tablr package  
+  should work now) by internalizing and patching document-register-element
+- Migrated away from `node-oniguruma` in favor of `vscode-oniguruma` (WASM  
+  version). This fixes issues with Electron 21
+- Ensured new WASM packages will work on Apple Silicon
+- Completions for HTML will now be as bleeding edge as possible.
+
+### Pulsar
+
+- Added: `settings-view` Support for Badges [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/451)
+- Removed: remove weird duplicate accented fixture file (hopefully?) [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/488)
+- Added: Add optional entitlements monkey-patch [@confused-Tecie](https://github.com/pulsar-edit/pulsar/pull/483)
+- Added: Decaf `wrap-guide` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/443)
+- Added: Additional Bundling of Core Packages [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/424)
+- Added: add allow-jit entitlement (fixes Apple Silicon builds) [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/454)
+- Removed: Revert "Create i18n API" [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/471)
+- Added: Build first, and test later [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/463)
+- Update: \[settings-view\] Update package snippets view to reflect new features [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/406)
+- Added: Create i18n API [@Meadowsys](https://github.com/pulsar-edit/pulsar/pull/446)
+- Added: Add Automated updating of `autocomplete-html` `completions.json` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/405)
+- Fixed: docs: fix markdown links in packages README [@oakmac](https://github.com/pulsar-edit/pulsar/pull/450)
+- Fixed: Patch document register element [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/438)
+- Added: Using "second-mate" [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/435)
+- Fixed: Fix spacing of PHP's "for ..." snippet [@machitgarha](https://github.com/pulsar-edit/pulsar/pull/440)
+- Update: Update resources metadata [@Spiker985](https://github.com/pulsar-edit/pulsar/pull/414)
+- Fixed: Cirrus: Windows: install ppm deps with Yarn [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/434)
+- Added: made cirrus build scripts consistent [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/239)
+- Update: Update package.json author [@Daeraxa](https://github.com/pulsar-edit/pulsar/pull/432)
+
+### second-mate
+
+- Added: Migrate to vscode-oniguruma [@mauricioszabo](https://github.com/pulsar-edit/second-mate/pull/1)
+
+### autosave
+
+- Removed: removed fs-plus dependency [@Sertonix](https://github.com/pulsar-edit/autosave/pull/2)
+- Update: Cleanup and rename [@Sertonix](https://github.com/pulsar-edit/autosave/pull/1)
+
+### bracket-matcher
+
+- Fixed: Fixing test that need to run locally [@mauricioszabo](https://github.com/pulsar-edit/bracket-matcher/pull/3)
+- Update: cleanup .md and rename repo url [@Sertonix](https://github.com/pulsar-edit/bracket-matcher/pull/2)
+- Update: Rename A\[a\]tom -> P\[p\]ulsar [@Spiker985](https://github.com/pulsar-edit/bracket-matcher/pull/1)
+
+### timecop
+
+- Update: cleanup and rename [@Sertonix](https://github.com/pulsar-edit/timecop/pull/1)
+
+### keybinding-resolver
+
+- Update: Cleanup and rename [@Sertonix](https://github.com/pulsar-edit/keybinding-resolver/pull/1)

--- a/docs/download.md
+++ b/docs/download.md
@@ -102,25 +102,27 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
+Current version is [v1.104.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0).
+
 ::: details Linux
 
 **x86_64** - For most desktops and laptops with Intel or AMD processors
 
-|                                                       Package                                                        |    Distribution    |
-| :------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar_1.103.0_amd64.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.x86_64.rpm)               |  Fedora/RHEL etc.  |
-| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.Pulsar-1.103.0.AppImage) | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Linux.pulsar-1.103.0.tar.gz)            | All distributions  |
+|                                                           Package                                                           |    Distribution    |
+| :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Linux.pulsar_1.104.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Linux.pulsar-1.104.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Linux.Pulsar-1.104.0.AppImage) | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Linux.pulsar-1.104.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
-|                                                         Package                                                          |    Distribution    |
-| :----------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar_1.103.0_arm64.deb)               | Debian/Ubuntu etc. |
-|              [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0.aarch64.rpm)               |  Fedora/RHEL etc.  |
-| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.Pulsar-1.103.0-arm64.AppImage) | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/ARM.Linux.pulsar-1.103.0-arm64.tar.gz)            | All distributions  |
+|                                                                Package                                                                |    Distribution    |
+| :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/ARM.Linux.pulsar_1.104.0_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/ARM.Linux.pulsar-1.104.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage<sup>[1][2]</sup>](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/ARM.Linux.Pulsar-1.104.0-arm64.AppImage) | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/ARM.Linux.pulsar-1.104.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -131,17 +133,17 @@ those instead.
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
-|                                             Package                                             |     Type      |
-| :---------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64.dmg) | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Silicon.Mac.Pulsar-1.103.0-arm64-mac.zip) |  Zip archive  |
+|                                                     Package                                                      |     Type      |
+| :--------------------------------------------------------------------------------------------------------------: | :-----------: |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Silicon.Mac.Pulsar-1.104.0-arm64.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Silicon.Mac.Pulsar-1.104.0-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
-|                                            Package                                            |     Type      |
-| :-------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0.dmg) | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Intel.Mac.Pulsar-1.103.0-mac.zip) |  Zip archive  |
+|                                                 Package                                                  |     Type      |
+| :------------------------------------------------------------------------------------------------------: | :-----------: |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Intel.Mac.Pulsar-1.104.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Intel.Mac.Pulsar-1.104.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -157,10 +159,10 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 :::
 
-|                                               Package                                               |         Type          |
-| :-------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.Setup.1.103.0.exe) |       Installer       |
-|  [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.103.0/Windows.Pulsar.1.103.0.exe)   | Portable (no install) |
+|                                                   Package                                                   |         Type          |
+| :---------------------------------------------------------------------------------------------------------: | :-------------------: |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Windows.Pulsar.Setup.1.104.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Windows.Pulsar-1.104.0-win.zip) | Portable (no install) |
 
 ::::
 


### PR DESCRIPTION
3 changes in one here but all relate to the new version.

1) New [BLOG] post - content is just copied from the release tag (with the exception of the excerpt and one heading
2) Regular download links updated to new releases
3) Extra section added above the regular releases to show what the current regular release version actually is without having to mouseover the links.

```
Current version is [v1.104.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0).
```