### PR TITLE
Update a couple of links for the 1.105.0 release

### DIFF
--- a/docs/blog/20230516-Daeraxa-v1.105.0.md
+++ b/docs/blog/20230516-Daeraxa-v1.105.0.md
@@ -8,7 +8,7 @@ tag:
   - release
 ---
 
-Welcome to a rad new release, Pulsar 1.105.0 is [available now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0)
+Welcome to a rad new release, Pulsar 1.105.0 is [available now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.105.0)
 
 <!-- more -->
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -105,7 +105,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.104.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0).
+Current version is [v1.105.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.105.0).
 
 ::: details Linux
 


### PR DESCRIPTION
Hi folks, thanks to @confused-Techie for mostly doing this release, and @Daeraxa for the blog post and download page link updates (#211).

I did notice that the link to the GitHub Release wasn't updated in a couple places when doing the blog post and download page links for 1.105.0, so it needs to be updated. Hence, this PR!

This PR updates the link to the GitHub Release for 1.105.0 from pointing to 1.104.0 --> now pointing to the 1.105.0 release on pulsar-edit/pulsar GitHub repo, in the new 1.105.0 release blog post and on the Regular release section of the download page where it notes what version the "current release" is.

Just a couple small edits following up on #211.