### PR TITLE
installing-pulsar: Add instructions for Gentoo

### DIFF
--- a/docs/docs/launch-manual/sections/getting-started/sections/installing-pulsar.md
+++ b/docs/docs/launch-manual/sections/getting-started/sections/installing-pulsar.md
@@ -68,6 +68,22 @@ $ sudo dnf install -y ./pulsar_1.100.0_amd64.rpm
 $ sudo yum install -y ./pulsar_1.100.0_amd64.rpm
 ```
 
+### Gentoo based distributions
+
+To install Pulsar on Gentoo or related distributions, enable the [GURU overlay](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users)
+and emerge the `app-editors/pulsar-bin` package.
+
+You can do this via the terminal:
+
+```
+# If GURU is not enabled already
+$ sudo emerge --noreplace app-eselect/eselect-repository
+$ sudo eselect repository enable guru
+$ sudo emerge --sync guru
+
+$ sudo emerge app-editors/pulsar-bin
+```
+
 @tab macOS
 
 Pulsar follows the standard macOS installation process. Grab the correct


### PR DESCRIPTION
I added the build files to the Gentoo GURU overlay yesterday (https://github.com/gentoo/guru/commit/2a8c35bcd8f74a3572b1e5fb868e268acd6b8d3d). I'll try my best to keep it up to date and I think that'll help adoption.

