### PR TITLE
Add 106 release blog post and update downloads page

### DIFF
--- a/docs/blog/20230616-Daeraxa-v1.106.0.md
+++ b/docs/blog/20230616-Daeraxa-v1.106.0.md
@@ -1,0 +1,73 @@
+---
+title: "Pulsar v1.106.0: A Focus on Grammars"
+author: Daeraxa
+date: 2023-06-15
+category:
+  - dev
+tag:
+  - release
+---
+
+Welcome to our latest release, Pulsar 1.106.0 is [available now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.106.0)
+
+<!-- more -->
+
+## What is new in 1.106.0?
+
+We have a particularly exciting release for you because this is our first regular release that adds a new feature that we have been hard at work on but more on that later. Of course we still have our usual mix of updates and upgrades such as a whole host of improvements to our Clojure language support and a number of annoying bugs that have been firmly splatted.
+
+As alluded to in the title our biggest update we have in store is our experimental modern Tree-sitter implementation. This is a really important feature for us as it allows us to move to a modern and actively developed implementation of [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) as well as allowing us to remove one of our obstacles in our quest to get onto modern versions of Electron. To be honest this is a huge topic in its own right, so if you want to read more about it then you can have a look at our [previous blog post](https://pulsar-edit.dev/blog/20230601-Daeraxa-JuneUpdate.html#tree-sitter-updates-are-live) which goes into a _lot_ more detail about this change. For now we have this under an experimental "opt-in" setting so to enable it you will need to go into your Settings and look for `Use Modern Tree-Sitter Implementation` in your `Core` settings in order to enable it. In short, if you enable it then you should see more accurate and consistent syntax highlighting, improved automatic indentation and better code folding. As ever we are keen for feedback on this feature so, once enabled, if you notice anything "off" or have any other comments or feedback then please let us know on [Discord](https://discord.gg/7aEbB9dGRT) or [file an issue](https://github.com/pulsar-edit/pulsar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
+
+Onto our Clojure language updates, lots of this actually ties directly into the new Tree-sitter implementation as Clojure is now supported as a Tree-sitter grammar which means a whole host of new features have been added that are specific to this new implementation. We now properly support block comments, quotes and a bunch of other advanced features. Basically there has never been a better time to pick up learning Clojure in Pulsar!
+
+Don't let these big updates make you assume we aren't also thinking about some smaller scale things, we have a tiny quality of life update to our GitHub package which adds a `Log Out` option to the package options (`Packages > GitHub > Log Out`) (previously only available in a somewhat obscure command - `github:logout`) - just beware that this will remove your token from your system entirely so you will either need to re-enter it or create a new one to log back in.
+
+And of course to finish up we have some annoying bugs which we have now been squashed, for example an issue that prevented images opening correctly (an issue we apparently inherited from Atom) and, whilst not a bug, a fix to solve a less than ideal situation with our new CSS autocomplete implementation to sort the suggestions in a more expected fashion. We have to thank our community for these as these last couple of items as they were brought to our attention (and in one case fixed) by some of our community members.
+
+So that just about wraps it up for another release. As ever a huge thank you to our wonderful community and donors who make this entire project possible.
+
+Till next time, happy coding, and see you among the stars!
+
+- The Pulsar Team
+
+<details>
+  <summary>A quick note about our missing ARM Linux Binaries</summary>
+  Sorry, there are no ARM Linux binaries at time of initial release, due to what we suspect is an issue at our CI provider. Hopefully this will be resolved soon and we can upload some ARM Linux binaries for this release! Thanks for your patience.
+</details>
+
+---
+
+### Changelog
+
+- Fixed bug that happens on some systems when trying to launch Pulsar using the Cinnamon desktop environment
+- Added a modern implementation of Tree-sitter grammars behind an experimental flag. Enable the “Use Modern Tree-Sitter Implementation” in the Core settings to try it out
+- Bugfix: fixed Clojure indentation on tree-sitter
+- Improved the Clojure language support by migrating it to tree-sitter and support block comments, quoting, and other advanced features on modern tree-sitter implementation
+- Fixed a bug that could cause images to not appear the first time opening them
+- `autocomplete-css` Completions are now sorted in a way that may match what users expect
+- Added a "Log Out" menu item for the `github` package
+
+### Pulsar
+
+- Updated: deps: Bump github to v0.36.16-pretranspiled [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/592)
+- Removed: Mostly remove `request` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/474)
+- Fixed: Fix: Image doesn't appear at first open [@asiloisad](https://github.com/pulsar-edit/pulsar/pull/579)
+- Removed: Remove specific cinnamon condition [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/563)
+- Fixed: Fix of Clojure's indentation rules by removing query file [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/584)
+- Fixed: Update links in settings page [@Daeraxa](https://github.com/pulsar-edit/pulsar/pull/570)
+- Added: \[autocomplete-css\] Sort `completions.json` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/552)
+- Fixed: Fixes on "comment block" for Clojure grammar [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/573)
+- Added: Hardcode NSIS GUID [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/566)
+- Fixed: Make yarn sane [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/567)
+- Fixed: Huge improvement on Clojure highlighting [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/553)
+- Removed: Removed unused_require method [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/561)
+- Bumped: Update dependency underscore to 1.12.1 \[SECURITY\] [@renovate](https://github.com/pulsar-edit/pulsar/pull/504)
+- Added: Add modern tree-sitter support behind an experimental flag [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/472)
+- Added: Make CHANGELOG easier to merge and update dompurify [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/537)
+- Added: js operators [@icecream17](https://github.com/pulsar-edit/pulsar/pull/79)
+- Bumped: Update dependency postcss to v8.2.13 \[SECURITY\] [@renovate](https://github.com/pulsar-edit/pulsar/pull/514)
+
+### github
+
+- Added: Add logout menu option [@Daeraxa](https://github.com/pulsar-edit/github/pull/27)
+- Updated: ci: Bump action dependencies [@Spiker985](https://github.com/pulsar-edit/github/pull/19)

--- a/docs/download.md
+++ b/docs/download.md
@@ -105,7 +105,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.105.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.105.0).
+Current version is [v1.106.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.106.0).
 
 ::: details Linux
 
@@ -113,12 +113,15 @@ Current version is [v1.105.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Linux.pulsar_1.105.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Linux.pulsar-1.105.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Linux.Pulsar-1.105.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Linux.pulsar-1.105.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Linux.pulsar_1.106.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Linux.pulsar-1.106.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Linux.Pulsar-1.106.0.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Linux.pulsar-1.106.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
+
+**Note** - ARM releases are currently still on v1.105.0 due to a suspected issue
+with our CI provider which will hopefully be resolved soon.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
@@ -138,15 +141,15 @@ Current version is [v1.105.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                     Package                                                      |     Type      |
 | :--------------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Silicon.Mac.Pulsar-1.105.0-arm64.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Silicon.Mac.Pulsar-1.105.0-arm64-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Silicon.Mac.Pulsar-1.106.0-arm64.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Silicon.Mac.Pulsar-1.106.0-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Intel.Mac.Pulsar-1.105.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Intel.Mac.Pulsar-1.105.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Intel.Mac.Pulsar-1.106.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Intel.Mac.Pulsar-1.106.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -164,12 +167,14 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Windows.Pulsar.Setup.1.105.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Windows.Pulsar-1.105.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Windows.Pulsar.Setup.1.106.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.106.0/Windows.Pulsar-1.106.0-win.zip) | Portable (no install) |
 
-|                        Package Manager                         |        Command         |
-| :------------------------------------------------------------: | :--------------------: |
-| [Chocolatey](https://community.chocolatey.org/packages/pulsar) | `choco install pulsar` |
+|                               Package Manager                                |        Command         |
+| :--------------------------------------------------------------------------: | :--------------------: |
+| [Chocolatey](https://community.chocolatey.org/packages/pulsar)<sup>[1]</sup> | `choco install pulsar` |
+
+[1] Our Chocolatey release is currently still on v1.103.0 due to file size restrictions but we are working to resolve this to provide proper support again.
 
 ::::
 
@@ -216,9 +221,9 @@ Two binaries are provided:
 
 Two binaries are currently available:
 
-- `Pulsar Setup...exe` is the installer based executable that will install Pulsar
+- `exe` is the installer based executable that will install Pulsar
   on your system
-- `Pulsar...exe` is the "portable" version which can run without needing to be
+- `zip` is the "portable" version which can run without needing to be
   installed on the system (for example from a flash drive).
 
 :::


### PR DESCRIPTION
- Adds the 106 release notes to the blog
- Updates the download page
    - Links updated to 106 binaries
    - Overall version updated
    - Note added to ARM binaries as currently on 105
    - Note added to Chocolatey as currently on 103
    - Updated manual download instructions as portable is no longer a .exe but a .zip