### PR TITLE
[BLOG] Remove breaking `less` change

### DIFF
--- a/docs/blog/20230701-Daeraxa-JulyUpdate.md
+++ b/docs/blog/20230701-Daeraxa-JulyUpdate.md
@@ -95,12 +95,11 @@ As ever we are after feedback, so if you use this new TOML Tree-sitter grammar (
 This is still in the works but [@confused-techie] has been making some updates to be added in the near future that bumps the version of `less-cache` that we are using.
 
 `less-cache` is a module that handles turning all Pulsar's (and our community's) packages written in [less](https://lesscss.org/) into valid CSS, as well as ensuring each one is able to import the values from Pulsar that it cares about. For the past three years `less-cache` has been using `less@3.12.2` which, while fine, has been missing out on some of the big new changes in less after version 4 was released.
-So [this PR](https://github.com/pulsar-edit/pulsar/pull/611) bumps it to `less-cache@2.0.0` in order to bump the version of `less` to 4.1.3. This change gives us some exciting new features, but it also introduces breaking changes to existing `less` stylesheets:
+So [this PR](https://github.com/pulsar-edit/pulsar/pull/611) bumps it to `less-cache@2.0.0` in order to bump the version of `less` to 4.1.3. This change gives us some exciting new features, but it also introduces a breaking change to existing `less` stylesheets:
 
-- Parentheses required for mixin calls (`.some-mixin()` instead of `.some-mixin`)
 - Parens-division now required around math expressions that use division
 
-See [less.js v4.0.0 change log](https://github.com/less/less.js/releases/tag/v4.0.0) for more info.
+See [less.js v4.0.0 -> v4.1.3 change logs](https://github.com/less/less.js/releases/tag/v4.0.0) for more info.
 
 The latter item has more impact: because `/` is used in newer CSS features like grids, parentheses are needed when doing division to remove ambiguity about the function of `/` on a particular line. Lots of usages in Pulsar core needed to be updated as a result of this, so it's quite possible that third-party packages are affected as well.
 


### PR DESCRIPTION
As noted during the 1.107.0 release notes, one of the breaking changes in less 4.0.0 was removed in 4.1.0. This update removes that line and rather than only linking to the 4.0.0 notes, encourages people to look at everything between 4.0.0 and 4.1.3 by linking to the general release page.