### PR TITLE
download: Fix link for "Current version is" (1.107.0 --> 1.107.1)

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -112,7 +112,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.107.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.107.0).
+Current version is [v1.107.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.107.1).
 
 ::: details Linux
 


### PR DESCRIPTION
A quick follow-up for one little link that got overlooked during https://github.com/pulsar-edit/pulsar-edit.github.io/pull/223.

Pseudo-markdown showing the change (or see the actual diff I guess):
> Current version is \[1.107.0\]\(~~1.107.0~~ --> 1.107.1\)

This only corrects the target URL; The text of the hyperlink was already gotten to during https://github.com/pulsar-edit/pulsar-edit.github.io/pull/223, and is therefore already correct.

_(Yes, this is a PR with a one-character-long diff.)_