### PR TITLE
Update "socials" common block and its uses

### DIFF
--- a/common-text-blocks.md
+++ b/common-text-blocks.md
@@ -10,7 +10,8 @@ Use the first two as sparingly as possible unless **_ABSOLUTELY_** necessary.
 ```
 ::: warning Under Construction
 This document is under construction, please check back soon for updates.
-Please see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and feel free to ask for assistance or inquire as to the status of this document.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
+inquire as to the status of this document.
 :::
 ```
 
@@ -18,7 +19,8 @@ Please see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and f
 
 ```
 ::: danger STOP
-This is being kept for archival purposes only from the original Atom documentation. As this may no longer be relevant to Pulsar, use this at your own risk.
+This is being kept for archival purposes only from the original Atom documentation.
+As this may no longer be relevant to Pulsar, use this at your own risk.
 Current Pulsar documentation is found at [documentation home](/docs/launch-manual/getting-started).
 :::
 ```

--- a/docs/docs/launch-manual/sections/behind-pulsar/index.md
+++ b/docs/docs/launch-manual/sections/behind-pulsar/index.md
@@ -7,8 +7,8 @@ description: Advanced Pulsar hacking
 # Behind Pulsar
 
 ::: warning Under Construction
-This document is under construction, please check back soon for updates. Please
-see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and feel free to ask for assistance or
+This document is under construction, please check back soon for updates.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
 inquire as to the status of this document.
 :::
 

--- a/docs/docs/launch-manual/sections/core-hacking/index.md
+++ b/docs/docs/launch-manual/sections/core-hacking/index.md
@@ -5,8 +5,8 @@ description: Info on building from source + hacking on Pulsar's core
 ---
 
 ::: warning Under Construction
-This document is under construction, please check back soon for updates. Please
-see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and feel free to ask for assistance or
+This document is under construction, please check back soon for updates.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
 inquire as to the status of this document.
 :::
 

--- a/docs/docs/launch-manual/sections/faq/index.md
+++ b/docs/docs/launch-manual/sections/faq/index.md
@@ -7,8 +7,8 @@ description: Frequently asked questions
 # FAQ
 
 ::: warning Under Construction
-This document is under construction, please check back soon for updates. Please
-see [our socials](link/to/socials/list) and feel free to ask for assistance or
+This document is under construction, please check back soon for updates.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
 inquire as to the status of this document.
 :::
 

--- a/docs/docs/launch-manual/sections/using-pulsar/index.md
+++ b/docs/docs/launch-manual/sections/using-pulsar/index.md
@@ -2,8 +2,8 @@
 
 ::: warning Under Construction
 This document is under construction, please check back soon for updates.
-Please see [our socials](/docs/launch-manual/sections/faq/#having-trouble) and
-feel free to ask for assistance or inquire as to the status of this document.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
+inquire as to the status of this document.
 :::
 
 @include(sections/pulsar-packages.md)

--- a/docs/docs/resources/pulsar-api/index.md
+++ b/docs/docs/resources/pulsar-api/index.md
@@ -4,5 +4,6 @@ title: Pulsar API
 
 ::: warning Under Construction
 This document is under construction, please check back soon for updates.
-Please see [our socials](link/to/socials/list) and feel free to ask for assistance or inquire as to the status of this document.
+Please see [our socials](/docs/community) and feel free to ask for assistance or
+inquire as to the status of this document.
 :::


### PR DESCRIPTION
Fixes https://github.com/pulsar-edit/pulsar-edit.github.io/issues/146, https://github.com/pulsar-edit/pulsar-edit.github.io/issues/233

Updates the common block to use our socials page at https://pulsar-edit.dev/community.html rather than the "get help" section from the FAQ.

Updates two previous iterations of block usage - one where it links to the get help section and one with a pseudo-link which should have never made it into the site anyway.