### PR TITLE
Update download links and add release blog post

### DIFF
--- a/docs/blog/20230916-Daeraxa-v1.109.0.md
+++ b/docs/blog/20230916-Daeraxa-v1.109.0.md
@@ -1,0 +1,85 @@
+---
+title: "Going the whole nine yards: Get Pulsar 1.109.0 now!"
+author: Daeraxa
+date: 2023-09-16
+category:
+  - dev
+tag:
+  - release
+---
+
+Going the whole nine yards: Get Pulsar [1.109.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.109.0) now!
+
+<!-- more -->
+
+## What do we have for you in Pulsar 1.109.0?
+
+Our next release has arrived, and, as ever, we are excited to share all the changes we have been making over the last month since our last release.
+
+We have a smorgasbord of bug fixes and quality of life improvements this month that we hope will make things just that bit better overall. Many of these changes are "behind the scenes", so you may not see much evidence of them when using Pulsar, but the _lack_ of any obvious changes means that we actually accomplished our goals of not disrupting the user experience.
+
+Starting things off is one of these "background" changes, but it was a massive amount of work that was put into the project in order to move CI platform. We have a fantastic [blog post](https://pulsar-edit.dev/blog/20230903-confused-Techie-pulsars-ci.html) on the topic that really goes into the full details of this change. This release marks the first (regular) release created after this change was made, which is why we feel it is important to mention it here even though you won't see anything different in Pulsar itself.
+
+To continue the trend of "background" changes, we have finally achieved our goal of removing all of the CoffeeScript code in the core editor and packages (a process dubbed "decaffeination") in favour of standard JavaScript. This was a goal started by the Atom team and has been a long time coming as, whilst it was good at the time, many of the features of CoffeeScript can now be found in vanilla JavaScript and migrating away from it allows a more unified codebase that is easier to maintain and lowers the barrier of entry for new contributors. Again, you won't really see anything within Pulsar itself, but this was a big achievement and we can finally draw a close to this little chapter.
+
+Onto some changes you _will_ see in Pulsar. Probably the most obvious one is our deprecation of the previous (and defunct) `autoUpdate` API. This is a follow-on from a change that first came into our `1.108.0` release to add the new core package `pulsar-updater`. You can read more about that particular change in the previous [release notes](https://pulsar-edit.dev/blog/20230816-DeeDeeG-v1.108.0.html#what-is-new-in-1-108-0). The most obvious result of this is the removal of the message on the `about` page telling you about automatic updates. This has instead been replaced with a link to the Readme of the `pulsar-updater` package reflecting the new situation.
+
+On the topic of the `about` package, we have some nice quality of life changes. The first of which is a change to how we link to the changelog/release notes. Previously, this would link to the changelog state as it was at that specific release. We have changed this to instead link to the relevant section on our `master` branch changelog. This not only allows us to properly support our rolling releases but also gives our regular releases quick access to look at upcoming changes. We also have a nice little update to improve the responsiveness of the pane when displayed in a narrow format; no longer do things get shoved and squished out of place.
+
+Now onto some bug fixes. The first one here regards a race condition that was found in our `autocomplete-plus` package, which was causing some weird situations where the suggestion list would open, close, then open again. This has now been fixed (with some handy assistance from the core package `keyboard-resolver` to help narrow down the problem).
+
+The next is specific to Windows users, where the Pulsar logo was not being shown (and was being replaced with a default blank icon) when Pulsar was set to be the file handler for selected file types. This has now been solved, and the logo should be displaying correctly.
+
+To finish things off, we have one change that improves resource usage quite considerably. However, in this case, we aren't talking about memory or CPU, but our cloud compute costs. What we found is that unnecessary requests were being made to our backend services by the `settings-view` package (which, amongst other things, is responsible for package management) for Pulsar's core packages. As the core packages aren't really designed to be updated between versions (that is why we have our [rolling release](https://pulsar-edit.dev/download.html#rolling-release)) there is no need to poll the backend for information such as the number of downloads or stargazers. The upshot of this change is that we are now saving a not-insignificant amount of money in backend costs. As this whole project is only possible due to our generous donors in the first place, this change means we can make better use of these funds that have been freed up. As always, our costs and expenses are transparent and open on our [Open Collective](https://opencollective.com/pulsar-edit) should you wish to see the effect.
+
+And that just about draws things to a close for this release. We have had a particularly busy month with some rather significant changes to all kinds of areas of Pulsar, so we hope you enjoy the update. As ever, a huge thank you to our generous donors and community, without whom this project would not be possible.
+
+Until next time, happy coding, and see you amongst the stars!
+
+- The Pulsar Team
+
+---
+
+- Fixed a race condition that could cause `autocomplete-plus` to ignore user input.
+- Fixed the `about` package linking to release notes for Pulsar.
+- Reduced the amount of network requests that `settings-view` creates.
+- Fixed the icon used when registering Pulsar as a file handler on Windows.
+- Removed the `autoUpdate` API from Pulsar, instead relying on the `pulsar-updater` package.
+- Prevented warnings in the developer console from appearing when autocomplete suggestions are shown.
+- Removed all CoffeeScript code from Pulsar and core packages.
+- Migrated the majority of our CI to GitHub Actions.
+
+### Pulsar
+
+- Added: about: Make the About page's CSS responsive for narrow panes [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/717)
+- Added: [core & settings-view] Avoid network requests for bundled packages [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/711)
+- Fixed: Remove @ from example to fix Documentation CI [@Spiker985](https://github.com/pulsar-edit/pulsar/pull/719)
+- Fixed: Cirrus: Don't update last good commit if CI skipped [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/716)
+- Fixed: Tree-sitter running fixes (August edition) [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/677)
+- Added: [status-bar & tree-view] Manual Decaf Source [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/707)
+- Added: [core] Consolidate app detail logic into single module [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/705)
+- Fixed: [about] Link release notes to `CHANGELOG.md` instead of tagged release of Pulsar [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/706)
+- Removed: Remove `fs-plus` from atom-protocol-handler [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/170)
+- Fixed: [core] Fix the icon used when registering Pulsar as a file handler in Windows [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/704)
+- Added: Decaf Packages Spec [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/700)
+- Removed: settings-view: Don't fix repository for core themes [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/702)
+- Added: Cirrus: Skip builds if same commit was previously built [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/701)
+- Fixed: CI: Tweak Cirrus build filter to allow tag pushes [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/699)
+- Added: Automatically rename binaries in CI during Regular releases [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/675)
+- Removed: remove repository fallback [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/264)
+- Added: [meta] GitHub Actions: Don't sign macOS builds from forked repo PRs [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/698)
+- Added: [meta] Ensure Actions can upload Rolling Releases [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/695)
+- Added: [meta] Cleanup `push` trigger, add `workflow_dispatch` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/694)
+- Added: Migrate most binary building to GitHub Actions [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/682)
+- Added: [meta] Add `ignorePaths` to renovate config [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/691)
+- Added: [language- && packages] Manual Decaf Spec Bundle [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/686)
+- Fixed: fix links of packages readme [@asiloisad](https://github.com/pulsar-edit/pulsar/pull/689)
+- Added: [meta] Add new and missing packages to renovate config [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/687)
+- Added: Small Update to Docs [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/621)
+- Fixed: [autocomplete-plus] Detect when menu state gets out of sync with DOM [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/680)
+- Removed: Remove AutoUpdate functionality from Core [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/668)
+- Bumped: Update autocomplete-html package [@renovate](https://github.com/pulsar-edit/pulsar/pull/688)
+- Added: [core]: Make showing tab title in window title optional [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/671)
+- Fixed: [autocomplete-plus] Suppress `marked` warnings [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/683)
+- Added: [pulsar-updater] Don't notify if Pulsar is running via `yarn start` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/679)
+- Bumped: bump actions/checkout to v3 [@casswedson](https://github.com/pulsar-edit/pulsar/pull/678)

--- a/docs/download.md
+++ b/docs/download.md
@@ -112,7 +112,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.108.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.108.0).
+Current version is [v1.109.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.109.0).
 
 ::: details Linux
 
@@ -120,19 +120,19 @@ Current version is [v1.108.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Linux.pulsar_1.108.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Linux.pulsar-1.108.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Linux.Pulsar-1.108.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Linux.pulsar-1.108.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Linux.pulsar_1.109.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Linux.pulsar-1.109.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Linux.Pulsar-1.109.0.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Linux.pulsar-1.109.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/ARM.Linux.pulsar_1.108.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/ARM.Linux.pulsar-1.108.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/ARM.Linux.Pulsar-1.108.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/ARM.Linux.pulsar-1.108.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/ARM.Linux.pulsar_1.109.0_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/ARM.Linux.pulsar-1.109.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/ARM.Linux.Pulsar-1.109.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/ARM.Linux.pulsar-1.109.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -149,17 +149,17 @@ Current version is [v1.108.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 **Silicon** - For Apple Silicon (M1/M2) macs
 
-|                                                     Package                                                      |     Type      |
-| :--------------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Silicon.Mac.Pulsar-1.108.0-arm64.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Silicon.Mac.Pulsar-1.108.0-arm64-mac.zip) |  Zip archive  |
+|                                                   Package                                                    |     Type      |
+| :----------------------------------------------------------------------------------------------------------: | :-----------: |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Silicon.Mac.Pulsar-1.109.0-arm64.dmg) | DMG installer |
+|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Intel.Mac.Pulsar-1.109.0-mac.zip)   |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Intel.Mac.Pulsar-1.108.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Intel.Mac.Pulsar-1.108.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Intel.Mac.Pulsar-1.109.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Intel.Mac.Pulsar-1.109.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -177,10 +177,10 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Windows.Pulsar.Setup.1.108.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Windows.Pulsar-1.108.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Windows.Pulsar.Setup.1.109.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.109.0/Windows.Pulsar-1.109.0-win.zip) | Portable (no install) |
 
-|                               Package Manager                  |        Command         |
+|                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |
 | [Chocolatey](https://community.chocolatey.org/packages/pulsar) | `choco install pulsar` |
 


### PR DESCRIPTION
As part of the 1.109.0 release.

https://github.com/pulsar-edit/pulsar/issues/721

Updates each download links and increments the current version.