### PR TITLE
Update manual download section to add GitHub Actions and update Cirrus CI section.

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -17,9 +17,10 @@ Note: There are no automatic updates at this time, regardless of which type of d
 ## Rolling Release
 
 These releases are built on each push to our `master` branch and automatically
-built by [Cirrus CI](https://cirrus-ci.com/github/pulsar-edit/pulsar). These
-releases come with the latest fixes, updates and improvements so this is a great
-choice if you want to get the latest features as soon as possible.
+built by [GitHub Actions](https://github.com/pulsar-edit/pulsar/actions/workflows/build.yml)
+and [Cirrus CI](https://cirrus-ci.com/github/pulsar-edit/pulsar).
+These releases come with the latest fixes, updates and improvements so this is a
+great choice if you want to get the latest features as soon as possible.
 
 While we do our best to review and test each PR thoroughly before merging there
 is a chance that something falls through the cracks in which case be prepared to
@@ -180,7 +181,7 @@ You can bypass this by clicking "More info" then "Run anyway".
 | [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Windows.Pulsar.Setup.1.108.0.exe)  |       Installer       |
 | [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.108.0/Windows.Pulsar-1.108.0-win.zip) | Portable (no install) |
 
-|                               Package Manager                  |        Command         |
+|                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |
 | [Chocolatey](https://community.chocolatey.org/packages/pulsar) | `choco install pulsar` |
 
@@ -192,18 +193,39 @@ Binaries are built from a number of different branches and PRs but you should
 stick to the **master** branch releases for the most stable ones unless you know
 exactly what you are looking for.
 
-To download a binary from Cirrus CI please follow the below steps:
+We currently build on both GitHub Actions and Cirrus CI:
+
+- GitHub Actions is used for building the majority of our binaries and builds
+  are run on every commit or PR.
+  - Direct artifact download is available only for those with at least read
+    permission on the repository. All artifacts are therefore automatically
+    uploaded to the [pulsar-edit/pulsar-rolling-releases](https://github.com/pulsar-edit/pulsar-rolling-releases/releases)
+    repository for access by anyone.
+- Cirrus CI is _only_ used for building Apple silicon (macOS M1/M2) and ARM
+  Linux binaries. These are run less frequently (every other day).
+
+To download a binary produced by GitHub Actions then follow the below steps:
+
+- Navigate to the [pulsar-edit/pulsar-rolling-releases](https://github.com/pulsar-edit/pulsar-rolling-releases/releases)
+  releases.
+- Select the most recent release (or for a specific release reference the timestamp
+  part of the version e.g. 1.109.**2023091606**).
+  - Most binaries will be available with every release but Apple silicon and
+    ARM Linux binaries will not. You may need to look for earlier releases.
+- Choose the binary you wish to download from the `Assets` section (you may need
+  click the `Show all x assets` link to display them all). See below for
+  descriptions of all available binaries.
+
+To download a binary from Cirrus CI (Apple silicon and ARM Linux only) please
+follow the below steps:
 
 - Go to the master branch [Pulsar Cirrus CI page](https://cirrus-ci.com/github/pulsar-edit/pulsar/master).
 - Select the latest successful build (check for a **_finished_** green check
   mark ✅ on the right side of the page - make sure you do not select a
   **_failed_** one).
 - Select your system from the list of options:
-  - **linux** - x86 Linux systems
   - **arm-linux** - ARM based Linux systems (Raspberry Pi etc.)
   - **silicon_mac** - M1 and M2 chip Apple Macs
-  - **intel_mac** - Intel chip Apple Macs
-  - **windows** - Microsoft Windows systems
 - Select **binary** > **binaries** from the **Artifacts** pane
 - Download the binary you require for your system:
 
@@ -211,7 +233,7 @@ To download a binary from Cirrus CI please follow the below steps:
 
 @tab Linux
 
-Four binaries are currently available:
+Four binaries are currently available for each architecture (amd64 & arm64):
 
 - `Appimage` for a universal Linux binary (should work on most systems)
 - `rpm` for Red Hat based OSs (Fedora, RHEL etc.)
@@ -220,7 +242,7 @@ Four binaries are currently available:
 
 @tab macOS
 
-Two binaries are provided:
+Two binaries are provided for each architecture (silicon_mac & intel_mac):
 
 - `dmg` standard installer image
 - `zip` containing the application binary for manual installation.


### PR DESCRIPTION
Updates the manual download section which previously only detailed how to download binaries from Cirrus CI.

- Adds a new GitHub Actions section and links to the `pulsar-rolling-releases` repo (as only people with read access to the main repo can download artifacts directly)
- Added section to explain what is produced on GHA vs Cirrus
- Updated a few areas to clarify things (like adding in architectures for binaries where they are distinct - previously this wasn't needed for Cirrus as architecture was selected before the binary).