### PR TITLE
Socials maintenance

### DIFF
--- a/docs/.vuepress/footer.js
+++ b/docs/.vuepress/footer.js
@@ -122,7 +122,7 @@ const footer =
       </a>
       <a href=${orgReddit}>
         <i class="fa-brands fa-reddit"></i>
-      <a href=${orgMastodon}>
+      <a rel="me" href=${orgMastodon}>
         <i class="fa-brands fa-mastodon"></i>
       </a>
       <a href=${orgLemmy}>

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -52,6 +52,11 @@ const navbar_en = [
         text: "Mastodon",
         icon: 'brands fa-mastodon',
         link: "https://fosstodon.org/@pulsaredit"
+      },
+      {
+        text: "Lemmy",
+        icon: 'solid fa-users',
+        link: "https://lemmy.ml/c/pulsaredit"
       }
     ]
   },


### PR DESCRIPTION
After I added Lemmy to the footer and community area I forgot to add it to the navbar. This PR addresses that.

It also adds a small change to our footer to add `rel="me"` into our Mastodon link in order to officially verify the page and account. Verification means that it is trusted more and can be allowed to trend on some instances.

See: https://cassidyjames.com/blog/mastodon-verification/

and:

![image](https://github.com/pulsar-edit/pulsar-edit.github.io/assets/58074586/0fb94b99-a752-4578-85fe-87534a130fb5)

If it works I'll look at adding it to other places we link to like GH.