### PR TITLE
Reduce number of stars in starfield (on homepage)

### DIFF
--- a/docs/.vuepress/components/Starfield.vue
+++ b/docs/.vuepress/components/Starfield.vue
@@ -5,7 +5,7 @@
     const _container = ref(null);
 
     onMounted(() => {
-        const COUNT = 800;
+        const COUNT = 40;
         const SPEED = 0.1;
         const BG_COLOR = 'rgba(26, 5, 40, 0.6)';
     


### PR DESCRIPTION
From **800** stars down to 40.

Should reduce CPU usage by a considerable amount. Also, a little less visually overwhelming, IMO.

I also considered 80 stars, which has similar performance on my computer, but I personally lean toward a subtler, less-is-more thing. It's a subjective aesthetics thing, though, to be honest.

**Open to suggestions for a better number of stars**, if people feel there is a better specific number. But less than 800, please.

Stopping the "up/down" animation of the pulsar logo would reduce CPU usage by a similar amount as this, as far as I was able to tell. But I ain't opening that can o' worms right now. One thing for this PR, something simple.