### PR TITLE
Prevent usage of git file creation times as page metadata

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -47,6 +47,7 @@ export default defineUserConfig({
       }
     },
     plugins: {
+			git: false,
       sitemap: {
         hostname: "https://pulsar-edit.dev",
         sitemapFilename: "sitemap.xml"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -47,7 +47,11 @@ export default defineUserConfig({
       }
     },
     plugins: {
-			git: false,
+			git: {
+				createdTime: false,
+				contributors: true,
+				updatedTime: true,
+			},
       sitemap: {
         hostname: "https://pulsar-edit.dev",
         sitemapFilename: "sitemap.xml"


### PR DESCRIPTION
In #254 we've got a situation where non-blog-post pages on the site carry meaningless dates. The [download page](https://pulsar-edit.dev/download.html) was first committed to Git almost one year ago, but there's no reason for VuePress to _show_ that date on the download page, because it isn't meaningful. It's the _opposite_ of meaningful, in fact; it could make people think that the content on that page hasn't been touched in a year.

Our VuePress theme looks at Git metadata to determine these dates. This could theoretically be useful for blog posts, but we're providing explicit `date` fields in the front matter of blog posts, so we don't actually need the Git plugin to tell us about the file's creation time. So let's turn that off! We can still choose to put an explicit date on any page we think deserves one.

If someone thinks that implicit date population is something that we might want to have on _some_ pages but not others, then we can have that discussion. But if not, disabling that feature of the git plugin would be the simplest way to fix #254.