### PR TITLE
v1.112.1 hotfix: Update download links and add blog post

### DIFF
--- a/docs/blog/20231219-DeeDeeG-v1.112.1.md
+++ b/docs/blog/20231219-DeeDeeG-v1.112.1.md
@@ -1,0 +1,23 @@
+---
+title: "Hotfix: Pulsar v1.112.1"
+author: DeeDeeG
+date: 2023-12-19
+category:
+  - dev
+tag:
+  - release
+---
+
+Hotfix: Pulsar 1.112.1 is [available now!](https://github.com/pulsar-edit/pulsar/releases/tag/v1.112.1)
+
+<!-- more -->
+
+## What is new in 1.112.1?
+
+Hotfix for important functionality within PPM.
+During recent refactoring of the PPM package, a bug was accidentally introduced that made it impossible for any package maintainer to publish a new package (or to publish new versions of their existing packages).
+An update was needed within PPM to restore this functionality to expected working order.
+
+Includes these PRs: https://github.com/pulsar-edit/ppm/pull/116 and https://github.com/pulsar-edit/ppm/pull/118 to fix the issue.
+
+See the [v1.112.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.112.0) release for all the other changes since v1.111.0.

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.112.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.112.0).
+Current version is [v1.112.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.112.1).
 
 ::: details Linux
 
@@ -121,19 +121,19 @@ Current version is [v1.112.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Linux.pulsar_1.112.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Linux.pulsar-1.112.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Linux.Pulsar-1.112.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Linux.pulsar-1.112.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Linux.pulsar_1.112.1_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Linux.pulsar-1.112.1.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Linux.Pulsar-1.112.1.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Linux.pulsar-1.112.1.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/ARM.Linux.pulsar_1.112.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/ARM.Linux.pulsar-1.112.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/ARM.Linux.Pulsar-1.112.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/ARM.Linux.pulsar-1.112.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/ARM.Linux.pulsar_1.112.1_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/ARM.Linux.pulsar-1.112.1.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/ARM.Linux.Pulsar-1.112.1-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/ARM.Linux.pulsar-1.112.1-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -152,15 +152,15 @@ Current version is [v1.112.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                   Package                                                    |     Type      |
 | :----------------------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Silicon.Mac.Pulsar-1.112.0-arm64.dmg) | DMG installer |
-|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Intel.Mac.Pulsar-1.112.0-mac.zip)   |  Zip archive  |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Silicon.Mac.Pulsar-1.112.1-arm64.dmg) | DMG installer |
+|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Intel.Mac.Pulsar-1.112.1-mac.zip)   |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Intel.Mac.Pulsar-1.112.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Intel.Mac.Pulsar-1.112.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Intel.Mac.Pulsar-1.112.1.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Intel.Mac.Pulsar-1.112.1-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -178,8 +178,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Windows.Pulsar.Setup.1.112.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.0/Windows.Pulsar-1.112.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Windows.Pulsar.Setup.1.112.1.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.112.1/Windows.Pulsar-1.112.1-win.zip) | Portable (no install) |
 
 |                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |


### PR DESCRIPTION
- Add a short/quick blog post to announce the hotfix release.
- Update the download links in `docs/download.md`.