### PR TITLE
deps: Update .github repo to latest (fix loading PRIVACY_POLICY.md)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   vuepress-theme-hope: 2.0.0-beta.106
 
 dependencies:
-  .github: github.com/pulsar-edit/.github/be58e3e9aa5243419278b508da531db52bd67258
+  .github: github.com/pulsar-edit/.github/1d7c3ddb51cc428c570ea5ad872304502a3fb145
   pulsar-assets: github.com/pulsar-edit/pulsar-assets/8fb8c787c296b789d5eea8dd65ea20c7a2af759d
   vuepress-theme-hope: 2.0.0-beta.106
 
@@ -2246,7 +2246,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /chownr/2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -3625,8 +3625,8 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -5738,7 +5738,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rollup/2.79.1:
@@ -5746,7 +5746,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6436,7 +6436,7 @@ packages:
       resolve: 1.22.1
       rollup: 2.77.3
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vue-demi/0.13.11_vue@3.2.45:
@@ -7072,8 +7072,8 @@ packages:
     resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
     dev: true
 
-  github.com/pulsar-edit/.github/be58e3e9aa5243419278b508da531db52bd67258:
-    resolution: {tarball: https://codeload.github.com/pulsar-edit/.github/tar.gz/be58e3e9aa5243419278b508da531db52bd67258}
+  github.com/pulsar-edit/.github/1d7c3ddb51cc428c570ea5ad872304502a3fb145:
+    resolution: {tarball: https://codeload.github.com/pulsar-edit/.github/tar.gz/1d7c3ddb51cc428c570ea5ad872304502a3fb145}
     name: .github
     version: 0.0.0
     dev: false


### PR DESCRIPTION
Ran `pnpm up .github` with pnpm 7.x latest (pnpm 7.33.6).

Update the commit hash for `.github` repo in our `pnpm-lock.yaml` PNPM lockfile, to fetch the latest revision of that repo.

Revision before this PR is too old to include `PRIVACY_POLICY.md`. This PR's change should pull in the `PRIVACY_POLICY.md` file, so we can display it on the website.

Fixes #161, probably?

---

Details:

I believe [what Meadow said about it](https://github.com/pulsar-edit/pulsar-edit.github.io/issues/161#issuecomment-1407788976) is basically right.

To reiterate and perhaps clarify further:
- [An exact commit SHA](https://github.com/pulsar-edit/.github/commit/be58e3e9aa5243419278b508da531db52bd67258) of `pulsar-edit/.github` repo is pinned in the lockfile. This commit is from November 2022.
- We want a commit SHA of `pulsar-edit/.github` repo that is at least from December 2022 or newer, when the `PRIVACY_POLICY.md` was added. See: https://github.com/pulsar-edit/.github/commits/main/PRIVACY_POLICY.md and https://github.com/pulsar-edit/.github/commit/5d2498ad7a699544c45eeb085826d9c5ed740791.
- CI is installing with `pnpm install --frozen-lockfile` (among other CLI arguments), so this dependency will _not_ automatically be updated in CI. But generally I don't expect `pnpm install` to mess with the lockfile, by default, other than to update to a new lockfile format but retaining the same dependencies/dependency version numbers, just recorded/laid out into the new format.
- After running `pnpm up .github`, the issue is fixed for me locally. The `@include` of `PRIVACY_POLICY.md` is working.
  - (`pnpm up` could hang in some cases, maybe just with older pnpm (?), due to some `git ls-remote` command under the hood hanging and then silently failing??? So, maybe that was giving people trouble at some point? It went away for me after updating to latest pnpm and also deleting my caches, not sure which solved it if either, since I did both at the same time... Also, perhaps it was a network error or me being rate-limited. and it just "went away on its own"/only an intermittent issue in the first place?)
- I believe it is not working for some people locally perhaps because they left `pnpm dev` running before updating the dep, relying on the auto-reload feature? But the `@include`s appear to be processed only once per run of  `pnpm dev` and then retained for the rest of that run... So, one has to quit the dev server and run `pnpm dev` again to load the new `PRIVACY_POLICY.md` file into the `@include`.