### PR TITLE
115 Release Blog Post and Download Link Updates

### DIFF
--- a/docs/blog/20240323-savetheclocktower-v1.115.0.md
+++ b/docs/blog/20240323-savetheclocktower-v1.115.0.md
@@ -1,0 +1,69 @@
+---
+title: "A week later than you’re accustomed to — but worth the wait! Pulsar 1.115.0 is available now!"
+author: savetheclocktower
+date: 2024-03-23
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.115.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.115.0) is available now!
+
+<!-- more -->
+
+## A week later than you’re accustomed to — but worth the wait! Pulsar 1.115.0 is available now!
+
+Last month’s 1.114.0 release was full of fixes related to the recent migration to modern Tree-sitter. This month’s release is much smaller, but still dominated by Tree-sitter fixes affecting syntax highlighting, code folding, and indentation.
+
+The most visible fixes are related to your ability to customize the grammar that Pulsar uses on a per-language basis. This is an approach we’ve encouraged for users that want or need to revert to an older grammar for a specific language — better to do so on a targeted basis than globally. If you can edit your config file, you can do per-language customization.
+
+For instance, now it’s even easier than before to say “use legacy Tree-sitter, but only for Python”:
+
+```coffeescript
+".python.source":
+  core:
+    useLegacyTreeSitter: true
+```
+
+Or “use modern Tree-sitter for JavaScript, but TextMate-style grammars everywhere else”:
+
+```coffeescript
+"*":
+  core:
+    useTreeSitterParsers: false
+".source.javascript":
+  core:
+    useTreeSitterParsers: true
+```
+
+Better yet, now the `grammar-selector` package will be attuned to these choices. When you manually reassign a buffer to use a different grammar, it will offer you only the “correct” grammar for each language based on what you’ve opted into.
+
+We’ve also delivered our customary incremental improvements in language support, and one change that affects nearly all languages: indentation hinting will be more accurate in transactions with multiple buffer changes. The most common example of a multi-edit transaction is when the user places more than one cursor and starts typing.
+
+We’ve made improvements to our `language-ruby` bundle, primarily with code folding and indentation hinting. TypeScript and C/C++ also got some small enhancements, and the `language-shellscript` bundle got a parser update.
+
+And lastly, on another note, we have a few maintenance and upkeep PR's to keep our Cirrus CI active and working, to ensure you can keep using and enjoying the latest builds Pulsar has to offer.
+
+Until next time, happy coding, and see you amongst the stars!
+
+- The Pulsar team
+
+---
+
+- Fixed some folds in Ruby like `unless`, some blocks, multiline comments, function calls, and different array syntaxes for strings and keywords.
+- Improved the accuracy of indentation hinting in modern Tree-sitter grammars, especially in multi-cursor scenarios.
+- Improved the ability of the user to opt into a specific kind of grammar for a specific language.
+- Changed the behavior of the `grammar-selector` package so that it will show the user's preferred grammar for a specific language.
+- Updated to version `0.20.9` of `web-tree-sitter`.
+- Improved syntax highlighting, indentation, and code folding in various languages, including TypeScript, shell scripts, Ruby, and C/C++.
+
+### Pulsar
+
+- Fixed: Fixed folds for Ruby [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/956)
+- Fixed: Tree-sitter fixes: 1.115 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/941)
+- Updated: cirrus: Update Rolling upload token again [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/960)
+- Fixed: cirrus: Various fixes for macOS Cirrus CI [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/961)
+- Fixed: Fix(fuzzy-finder) fs.lstatSync throws Exception if not a file or dir [@schadomi7](https://github.com/pulsar-edit/pulsar/pull/944)
+- Updated: CI: Update Rolling upload token for Cirrus CI [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/936)
+- Updated: Cirrus: Install older dotenv gem version ~> 2.8 (< 3) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/937)

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.114.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.114.0).
+Current version is [v1.115.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.115.0).
 
 ::: details Linux
 
@@ -121,19 +121,19 @@ Current version is [v1.114.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Linux.pulsar_1.114.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Linux.pulsar-1.114.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Linux.Pulsar-1.114.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Linux.pulsar-1.114.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Linux.pulsar_1.115.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Linux.pulsar-1.115.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Linux.Pulsar-1.115.0.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Linux.pulsar-1.115.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/ARM.Linux.pulsar_1.114.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/ARM.Linux.pulsar-1.114.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/ARM.Linux.Pulsar-1.114.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/ARM.Linux.pulsar-1.114.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/ARM.Linux.pulsar_1.115.0_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/ARM.Linux.pulsar-1.115.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/ARM.Linux.Pulsar-1.115.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/ARM.Linux.pulsar-1.115.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -152,15 +152,15 @@ Current version is [v1.114.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                   Package                                                    |     Type      |
 | :----------------------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Silicon.Mac.Pulsar-1.114.0-arm64.dmg) | DMG installer |
-|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Intel.Mac.Pulsar-1.114.0-mac.zip)   |  Zip archive  |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Silicon.Mac.Pulsar-1.115.0-arm64.dmg) | DMG installer |
+|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Intel.Mac.Pulsar-1.115.0-mac.zip)   |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Intel.Mac.Pulsar-1.114.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Intel.Mac.Pulsar-1.114.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Intel.Mac.Pulsar-1.115.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Intel.Mac.Pulsar-1.115.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -178,8 +178,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Windows.Pulsar.Setup.1.114.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.114.0/Windows.Pulsar-1.114.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Windows.Pulsar.Setup.1.115.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.115.0/Windows.Pulsar-1.115.0-win.zip) | Portable (no install) |
 
 |                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |


### PR DESCRIPTION
Here's the PR to add the release announcement blog post for 1.115.0, and update the download links accordingly.

The blurb this post is based on is mostly by @savetheclocktower, just with my note added at the end about the Cirrus fixes, and formatting and such. That's why they're listed as the author for the blog post, since they wrote it, essentially.

Working through that release checklist!