### PR TITLE
Update download links and add blog post for Pulsar v1.117.0

### DIFF
--- a/docs/blog/20240520-confused-Techie-v1.117.0.md
+++ b/docs/blog/20240520-confused-Techie-v1.117.0.md
@@ -14,11 +14,13 @@ Pulsar [1.117.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.117.0) is
 
 ## Pulsar 1.117.0: With special love for Markdown and Tree-sitter
 
-As somewhat expected, this release is full of new improvements for Tree-sitter grammars! With SCSS now having Tree-sitter support, to Ruby getting an updated parser, or performance and highlighting enhancements in Markdown and TypeScript there's hopefully something in there for everybody. Speaking of Markdown, the `markdown-preview` package has gotten new features and improvements with significant performance increases in the preview pane and rendering fenced code blocks, while still boasting brand new dark mode support! But dark mode support doesn't stop there, Pulsar now, optionally, supports OS-level dark mode that syncs with the actively selected Theme within the app, meaning that if enabled Pulsar will change its window theme within the OS to match any built-in or community theme.
+As you may have come to expect, this release is full of new improvements for Tree-sitter grammars! From SCSS now having Tree-sitter support, to Ruby getting an updated parser, to performance and highlighting enhancements in Markdown and TypeScript, there's hopefully something in there for everybody.
+
+Speaking of Markdown, the `markdown-preview` package has gotten significant performance increases in the preview pane (especially for documents with lots of fenced code blocks), and boasts brand new dark mode support for the "GitHub.com style" option!
+
+But dark mode support doesn't stop there! Pulsar can now (optionally) use the OS-level dark mode window theme, switching automatically based on the lightness or darkness of the colors in the active Pulsar theme if enabled.
 
 Beyond the fixes and features within the editor itself, you'll be glad to know this release also saw many improvements for our Continuous Integration to ensure we can deliver timely and bug-free updates in the future.
-
-Until next time, happy coding, and see you amongst the stars!
 \- The Pulsar team
 
 ---

--- a/docs/blog/20240520-confused-Techie-v1.117.0.md
+++ b/docs/blog/20240520-confused-Techie-v1.117.0.md
@@ -1,0 +1,48 @@
+---
+title: "With special love for Markdown and Tree-sitter, Pulsar 1.117.0 is available now!"
+author: confused-Techie
+date: 2024-05-20
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.117.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.117.0) is available now!
+
+<!-- more -->
+
+## Pulsar 1.117.0: With special love for Markdown and Tree-sitter
+
+As somewhat expected, this release is full of new improvements for Tree-sitter grammars! With SCSS now having Tree-sitter support, to Ruby getting an updated parser, or performance and highlighting enhancements in Markdown and TypeScript there's hopefully something in there for everybody. Speaking of Markdown, the `markdown-preview` package has gotten new features and improvements with significant performance increases in the preview pane and rendering fenced code blocks, while still boasting brand new dark mode support! But dark mode support doesn't stop there, Pulsar now, optionally, supports OS-level dark mode that syncs with the actively selected Theme within the app, meaning that if enabled Pulsar will change its window theme within the OS to match any built-in or community theme.
+
+Beyond the fixes and features within the editor itself, you'll be glad to know this release also saw many improvements for our Continuous Integration to ensure we can deliver timely and bug-free updates in the future.
+
+Until next time, happy coding, and see you amongst the stars!
+\- The Pulsar team
+
+---
+
+- [markdown-preview] Improve rendering performance in preview panes, especially in documents with lots of fenced code blocks.
+- [markdown-preview] GitHub-style Markdown preview now uses up-to-date styles and supports dark mode.
+- Pulsar's OS level theme will now change according to the selected editor theme if `core.syncWindowThemeWithPulsarTheme` is enabled.
+- [language-sass] Add SCSS Tree-sitter grammar.
+- [language-ruby] Update to latest Tree-sitter Ruby parser.
+- [language-gfm] Make each block-level HTML tag its own injection.
+- [language-typescript] More highlighting fixes, especially for operators.
+
+### Pulsar
+
+- Fixed: Cirrus: Fix gem install fpm on ARM Linux [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1008)
+- Updated: [ci] Update Cirrus CI Token [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1006)
+- Fixed: CI: Fix workaround for Homebrew node in Cirrus on macOS [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1002)
+- Added: [markdown-preview] Optimize re-rendering of content in a preview pane especially syntax highlighting [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/984)
+- Fixed: Tree-sitter rolling fixes, 1.117 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/974)
+- Updated: Update Renovate preset name [@HonkingGoose](https://github.com/pulsar-edit/pulsar/pull/1000)
+- Added: Debugging when a package service is incorrect [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/995)
+- Added: Bundle snippets [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/993)
+- Fixed: CI: Pin to macOS 12 runner images instead of macos-latest (GitHub Actions) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/997)
+- Added: [markdown-preview] Add dark mode for GitHub-style preview [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/973)
+- Added: Change Window Theme with Pulsar Theme [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/545)
+- Updated: CI: Upgrade or replace all deprecated GH Actions [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/983)
+- Fixed: [language-clojure] Stop detecting `.org` files as `.language-clojure` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/980)

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.116.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.116.0).
+Current version is [v1.117.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.117.0).
 
 ::: details Linux
 
@@ -121,19 +121,19 @@ Current version is [v1.116.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Linux.pulsar_1.116.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Linux.pulsar-1.116.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Linux.Pulsar-1.116.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Linux.pulsar-1.116.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Linux.pulsar_1.117.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Linux.pulsar-1.117.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Linux.Pulsar-1.117.0.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Linux.pulsar-1.117.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/ARM.Linux.pulsar_1.116.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/ARM.Linux.pulsar-1.116.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/ARM.Linux.Pulsar-1.116.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/ARM.Linux.pulsar-1.116.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/ARM.Linux.pulsar_1.117.0_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/ARM.Linux.pulsar-1.117.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/ARM.Linux.Pulsar-1.117.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/ARM.Linux.pulsar-1.117.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -152,15 +152,15 @@ Current version is [v1.116.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                   Package                                                    |     Type      |
 | :----------------------------------------------------------------------------------------------------------: | :-----------: |
-| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Silicon.Mac.Pulsar-1.116.0-arm64.dmg) | DMG installer |
-|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Intel.Mac.Pulsar-1.116.0-mac.zip)   |  Zip archive  |
+| [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Silicon.Mac.Pulsar-1.117.0-arm64.dmg) | DMG installer |
+|   [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Intel.Mac.Pulsar-1.117.0-mac.zip)   |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Intel.Mac.Pulsar-1.116.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Intel.Mac.Pulsar-1.116.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Intel.Mac.Pulsar-1.117.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Intel.Mac.Pulsar-1.117.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -178,8 +178,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Windows.Pulsar.Setup.1.116.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.116.0/Windows.Pulsar-1.116.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Windows.Pulsar.Setup.1.117.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.117.0/Windows.Pulsar-1.117.0-win.zip) | Portable (no install) |
 
 |                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |


### PR DESCRIPTION
Note: The blog post content for this Pulsar v1.117.0 release was written by confused-Techie. This is just posting that content here as a new blog post and updating the download links from 1.116.0 to 1.117.0.

### Alternative blurb option

Also consider this alternate blurb re-worked by me, I posted this in the Discord and did not receive any outright feedback there, so I went with the existing blurb by @confused-Techie to be safer. But we have this as an option:

> As you may have come to expect, this release is full of new improvements for Tree-sitter grammars! From SCSS now having Tree-sitter support, to Ruby getting an updated parser, to performance and highlighting enhancements in Markdown and TypeScript, there's hopefully something in there for everybody. Speaking of Markdown, the `markdown-preview` package has gotten significant performance increases in the preview pane (especially for documents with lots of fenced code blocks), and boasts brand new dark mode support for the "GitHub.com style" option! But dark mode support doesn't stop there! Pulsar can now (optionally) use the OS's light or dark mode window theming based on the active Pulsar theme. This works with any built-in or community theme based on its color values.
> 
> Beyond the fixes and features within the editor itself, you'll be glad to know this release also saw many improvements for our Continuous Integration to ensure we can deliver timely and bug-free updates in the future.

I'd be okay to go over this and receive suggestions/feedback, either here or on Discord, if there is a desire to go over the blog post wording with a finer-toothed comb. But it works as-is too (as @confused-Techie wrote it, which is how it is committed for this PR already). So this ^ text is just an alternate second draft to consider.