### PR TITLE
Upgrade 'pnpm/action-setup' to resolve test deployment errors

### DIFF
--- a/.github/workflows/test-deploy-pnpm.yaml
+++ b/.github/workflows/test-deploy-pnpm.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
       # You may pin to the exact commit or the version.
       # uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v4
         with:
           version: 7
           run_install: |


### PR DESCRIPTION
According to this [conversation](https://github.com/pnpm/action-setup/issues/135#issuecomment-2206861174) the older version of `pnpm/action-setup` we are using is broken, and simply updating it will resolve the issues we are seeing on #277 