### PR TITLE
Upgrade 'pnpm/action-setup' to v4 in all CI workflows

### DIFF
--- a/.github/workflows/deploy-pnpm.yaml
+++ b/.github/workflows/deploy-pnpm.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -16,7 +16,7 @@ jobs:
          uses: actions/setup-node@v3
          with:
            node-version: '16'
-       - uses: pnpm/action-setup@v2.2.2
+       - uses: pnpm/action-setup@v4
         with:
           version: 6.0.2
           run_install: |


### PR DESCRIPTION
Follow-up to PR #279, where specifically the test-deploy-pnpm.yaml workflow was updated.

Given that there is some deprecation or issue affecting the v2.x series of this action, it seems we must upgrade this version of the action. Only the test-deploy-pnpm workflow file was updated in #279, but apparently we have a separate workflow for production v.s. for testing PRs. For instance: the production deployment workflow failed when running for the new blog post PR landing. https://github.com/pulsar-edit/pulsar-edit.github.io/actions/runs/10013685234/job/27681843023

So, given we have demonstrated that the fix works via #279, this is just a follow-up to apply the fix in more places. Thanks to @confused-Techie for confirming this works as the fix. Reviews appreciated so production can go brr again.