### PR TITLE
Fix indentation (also tweak newlines/whitespace) in CI workflow yaml files

### DIFF
--- a/.github/workflows/deploy-pnpm.yaml
+++ b/.github/workflows/deploy-pnpm.yaml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
       - name: Build VuePress Site
         run: pnpm build
+
       - name: Deploy to GitHub Pages
         uses: crazy-max/ghaction-github-pages@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,9 +43,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
       - name: Build VuePress Site
         run: pnpm build
-
 
       # please check out the docs of the workflow for more details
       # @see https://github.com/crazy-max/ghaction-github-pages

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-# Workflow to lint Markdown provided 
+# Workflow to lint Markdown provided
 
 name: Lint
 
@@ -40,6 +40,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Run Linting 
-        run: pnpm lint 
-      
+      - name: Run Linting
+        run: pnpm lint

--- a/.github/workflows/spell-checker.yaml
+++ b/.github/workflows/spell-checker.yaml
@@ -1,6 +1,6 @@
-# Workflow to test the spelling within the PR 
+# Workflow to test the spelling within the PR
 
-name: Spell Checker 
+name: Spell Checker
 
 on:
   pull_request:
@@ -8,13 +8,14 @@ on:
 
 jobs:
   spellcheck:
-    runs-on: ubuntu-latest 
-    name: Spellcheck 
+    runs-on: ubuntu-latest
+    name: Spellcheck
     steps:
       - uses: actions/checkout@v3
+
       - uses: tbroadley/spellchecker-cli-action@v1
         with:
-          quiet: true # Dont output anything if the file contains no spelling mistakes 
+          quiet: true # Dont output anything if the file contains no spelling mistakes
           files: "docs/**/**/*.md !docs/.vuepress"
           language: "en-US"
           dictionaries: "./tools/spell-checker-dictionary.txt"

--- a/.github/workflows/test-deploy-pnpm.yaml
+++ b/.github/workflows/test-deploy-pnpm.yaml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+
       - name: Setup pnpm
       # You may pin to the exact commit or the version.
       # uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
@@ -28,7 +30,9 @@ jobs:
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
             - args: [--global, prettier, gulp]
+
       - name: Install Dependencies
         run: pnpm install
+
       - name: Test Build
         run: pnpm build

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -12,15 +12,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+
       - uses: pnpm/action-setup@v4
         with:
           version: 6.0.2
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
+
       - name: Test Build
         run: pnpm build

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-       - uses: actions/checkout@v3
-       - name: Setup Node.js
-         uses: actions/setup-node@v3
-         with:
-           node-version: '16'
-       - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - uses: pnpm/action-setup@v4
         with:
           version: 6.0.2
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
-       - name: Test Build
-         run: pnpm build
+      - name: Test Build
+        run: pnpm build


### PR DESCRIPTION
**tl;dr: Some whitespace-only tweaks to this repo's CI yaml worfklow files.**



**First commit in this PR branch:**

Fixes an off bit of indentation in one of the workflow .yaml files, **per @savetheclocktower's comment pointing it out in this comment: https://github.com/pulsar-edit/pulsar-edit.github.io/commit/d747eda4bd4b102ff863f787001ed9ab1367ccd7#r146063988.** (I think I may have run into this before and chosen to ignore it at the time, but feels better to me now to fix it after all.)

**Second commit in this PR branch (optional, reviewers tell me whether you'd like this removed):**

Also normalizes use of newlines in the workflow.yaml files: Always a blank line in-between steps, no matter what. Makes things more uniform, tidy and skimmable without missing things, IMO. Since they might not have appeared to be separate steps if not looked at closely. Makes the reader pause and consider that these are separate and distinct steps. Good for distracted troubleshooting, which is most troubleshooting, IMO.

Also, Pulsar automatically stripped some trailing spaces in the process... I committed these as well.

**Note: Potential third commit?:** (reviewers let me know if you're interested in this being added to the repo. can keep things tidy when reviewing commit histories. And help to not discourage formatting improvements for fear of "polluting the blame history.")

Can add this as a `.git-blame-ignore-revs` file to keep the blame view clean and ignore these commits when trying to suss out what actually went wrong with these files in the future, if anything:

```text
### Run this command to always ignore formatting commits in `git blame` ###
###        git config blame.ignoreRevsFile .git-blame-ignore-revs       ###

# Normalizing whitespace in the CI yml files
7080c53b05fe211c12fce2dac7fd976fb86ac3cb
35257b0ffb3e0c5faea64a4e032f6a9bf3c605ae
```