### PR TITLE
Use full paths for APM_PATH values

### DIFF
--- a/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
+++ b/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
@@ -16,7 +16,7 @@ To solve this a couple of environmental variables need to be exported.
 
 ```sh
 export ATOM_HOME=/home/<user>/.pulsar
-export APM_PATH=/ppm/bin/apm
+export APM_PATH=<pulsar source>/ppm/bin/apm
 export ATOM_ELECTRON_VERSION=12.2.3
 ```
 
@@ -30,7 +30,7 @@ TODO
 
 ```sh
 set ATOM_HOME=C:\Users\<user>\.pulsar
-set APM_PATH=\ppm\bin\apm
+set APM_PATH=<pulsar source>\ppm\bin\apm
 ```
 
 :::


### PR DESCRIPTION
This PR suggests filling in values for `APM_PATH` to be full-paths.

At the time of writing, the docs [here](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#using-ppm-pulsar-package-manager) mention:

```sh
export APM_PATH=/ppm/bin/apm
```

At least on Linux when I tried with the suggested value, the settings-view would not populate appropriately (and I believe there were other adverse side-effects as an appropriate `apm` binary was not being called).

Using a full-path did work however.

The PR suggests prepending the existing value with `<pulsar-source>` like:

```sh
export APM_PATH=<pulsar-source>/ppm/bin/apm
```

`<pulsar-source>` was chosen as it is used at the end of the same section in an example:

```sh
# from the directory where you are running pulsar source code
<pulsar source>/ppm/bin/apm link
```
