### PR TITLE
Provide a pointer to the pulsar API documentation -and its home page-

### DIFF
--- a/docs/docs/resources/pulsar-api/index.md
+++ b/docs/docs/resources/pulsar-api/index.md
@@ -7,3 +7,5 @@ This document is under construction, please check back soon for updates.
 Please see [our socials](/docs/community) and feel free to ask for assistance or
 inquire as to the status of this document.
 :::
+
+[The latest API documentation](https://docs.pulsar-edit.dev/api/pulsar/latest/) is available on the [Pulsar documentation site](https://docs.pulsar-edit.dev/), as well as a wealth of other technical documentation.


### PR DESCRIPTION
I think this page is a good location to mention the point to the API documentation.

You may change the formulation, I really don't know how to present the Pulsar documentation web page.