### PR TITLE
Correct value for APM_PATH on Linux

### DIFF
--- a/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
+++ b/docs/docs/launch-manual/sections/core-hacking/sections/using-ppm.md
@@ -16,7 +16,8 @@ To solve this a couple of environmental variables need to be exported.
 
 ```sh
 export ATOM_HOME=/home/<user>/.pulsar
-export APM_PATH=/ppm/bin/apm
+# With <pulsar_clone> the path of your clone of the git repository of pulsar
+export APM_PATH=<pulsar_clone>/ppm/bin/apm
 export ATOM_ELECTRON_VERSION=12.2.3
 ```
 


### PR DESCRIPTION
I noticed that when I launch Pulsar from the command line with `export APM_PATH=/ppm/bin/apm` sourced from my environment file, the 'Installed packages' view was broken : 

![image](https://github.com/user-attachments/assets/8c5758e8-9108-4485-aeaf-34d4528206c0)

However I did not have that problem using the pinned icon on my launch dock of the desktop (Ubuntu).

It turns out that `APM_PATH` MUST point to the full path of `apm`.

I suspect that it should be the same for Windows, but I cannot perform such verification.

Hope this helps. :) 