### PR TITLE
Add blog posts and update download links for Pulsar 1.127.0 & Hotfix 1.127.1

### DIFF
--- a/docs/blog/20250326-DeeDeeG-v1.127.0.md
+++ b/docs/blog/20250326-DeeDeeG-v1.127.0.md
@@ -1,0 +1,45 @@
+---
+title: "Pulsar v1.127.0: Marching to the Beat of our own Drum"
+author: DeeDeeG
+date: 2025-03-26
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.127.0: Marching to the beat of our Own Drum
+
+Another release to round out this month. Enjoy.
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Added a Jasmine 2-based test runner, migrated core editor tests to use it. Packages bundled into the core editor can migrate their tests to use this as well, over time. The Jasmine 1 test runner remains available.
+- Added `--enable-features=UseOzonePlatform` and `--ozone-platform=wayland` as parameters when running under Wayland on Linux (avoids using xwayland, which causes rendering problems on some systems, especially with NVidia)
+- Many Tree-sitter/parser/grammar improvements.
+  - Updated to `web-tree-sitter` version `0.25.3`.
+  - Fixed a bug preventing folds from updating after code changes in some scenarios.
+  - Better folding behavior in Python.
+  - Better folding and syntax highlighting in Ruby of `case`/`in` statements.
+  - Better syntax highlighting of private members in JavScript.
+  - Better folding of multiline comments in PHP.
+- Updated the `read` dependency in ppm
+
+### Pulsar
+
+- ppm: Update ppm to commit a6f843f0381f64cb5865efc7 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1252)
+- Tree-sitter rolling fixes, 1.127 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1240)
+- Wayland pulsar script [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1246)
+- Update jasmine to 2.x [@kiskoza](https://github.com/pulsar-edit/pulsar/pull/990)
+
+### ppm
+
+- Update to read v3 [@2colours](https://github.com/pulsar-edit/ppm/pull/150)

--- a/docs/blog/20250329-DeeDeeG-v1.127.1.md
+++ b/docs/blog/20250329-DeeDeeG-v1.127.1.md
@@ -1,0 +1,31 @@
+---
+title: "Pulsar v1.127.1 (Hotfix)"
+author: DeeDeeG
+date: 2025-03-29
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.127.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.1) is available now!
+
+<!-- more -->
+
+## Pulsar v1.127.1 (Hotfix)
+
+Here's a quick hotfix release, reverting a change that caused an issue for Linux users.
+
+(For all other changes since v1.126.0, please see the release notes for v1.127.0.)
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Hotfix: Reverted a Wayland-related change that Linux users reported issues with on Electron 12.
+
+### Pulsar
+
+- Revert "Wayland pulsar script" [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1261)

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.0).
+Current version is [v1.127.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.1).
 
 ::: details Linux
 
@@ -121,19 +121,19 @@ Current version is [v1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar_1.127.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar-1.127.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.Pulsar-1.127.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar-1.127.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Linux.pulsar_1.127.1_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Linux.pulsar-1.127.1.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Linux.Pulsar-1.127.1.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Linux.pulsar-1.127.1.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar_1.127.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar-1.127.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.Pulsar-1.127.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar-1.127.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/ARM.Linux.pulsar_1.127.1_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/ARM.Linux.pulsar-1.127.1.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/ARM.Linux.Pulsar-1.127.1-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/ARM.Linux.pulsar-1.127.1-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -152,15 +152,15 @@ Current version is [v1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                     Package                                                      |     Type      |
 | :--------------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Silicon.Mac.Pulsar-1.127.0-arm64.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Silicon.Mac.Pulsar-1.127.0-arm64-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Silicon.Mac.Pulsar-1.127.1-arm64.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Silicon.Mac.Pulsar-1.127.1-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Intel.Mac.Pulsar-1.127.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Intel.Mac.Pulsar-1.127.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Intel.Mac.Pulsar-1.127.1.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Intel.Mac.Pulsar-1.127.1-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -178,8 +178,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Windows.Pulsar.Setup.1.127.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Windows.Pulsar-1.127.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Windows.Pulsar.Setup.1.127.1.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.1/Windows.Pulsar-1.127.1-win.zip) | Portable (no install) |
 
 |                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ feature issues that have already been resolved in our Rolling Release so if a
 particular fix or feature is important to you it may be worth swapping to one of
 those instead.
 
-Current version is [v1.126.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.126.0).
+Current version is [v1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.0).
 
 ::: details Linux
 
@@ -121,19 +121,19 @@ Current version is [v1.126.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                           Package                                                           |    Distribution    |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Linux.pulsar_1.126.0_amd64.deb)            | Debian/Ubuntu etc. |
-|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Linux.pulsar-1.126.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Linux.Pulsar-1.126.0.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Linux.pulsar-1.126.0.tar.gz)            | All distributions  |
+|           [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar_1.127.0_amd64.deb)            | Debian/Ubuntu etc. |
+|           [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar-1.127.0.x86_64.rpm)           |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.Pulsar-1.127.0.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Linux.pulsar-1.127.0.tar.gz)            | All distributions  |
 
 **ARM_64** - For ARM based devices - Raspberry Pi, Pinebook etc.
 
 |                                                                Package                                                                |    Distribution    |
 | :-----------------------------------------------------------------------------------------------------------------------------------: | :----------------: |
-|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/ARM.Linux.pulsar_1.126.0_arm64.deb)               | Debian/Ubuntu etc. |
-|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/ARM.Linux.pulsar-1.126.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
-| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/ARM.Linux.Pulsar-1.126.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
-|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/ARM.Linux.pulsar-1.126.0-arm64.tar.gz)            | All distributions  |
+|              [deb](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar_1.127.0_arm64.deb)               | Debian/Ubuntu etc. |
+|             [rpm](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar-1.127.0.aarch64.rpm)              |  Fedora/RHEL etc.  |
+| [AppImage](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.Pulsar-1.127.0-arm64.AppImage)<sup>[1][2]</sup> | All distributions  |
+|           [tar.gz](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/ARM.Linux.pulsar-1.127.0-arm64.tar.gz)            | All distributions  |
 
 [1] Appimage may require `--no-sandbox` as an argument to run correctly on some systems.  
 [2] Some distributions no longer ship with `libfuse2` which Appimage requires to run. You may need to install this manually, e.g on Ubuntu >=22.04 `apt install libfuse2`.
@@ -152,15 +152,15 @@ Current version is [v1.126.0](https://github.com/pulsar-edit/pulsar/releases/tag
 
 |                                                     Package                                                      |     Type      |
 | :--------------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Silicon.Mac.Pulsar-1.126.0-arm64.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Silicon.Mac.Pulsar-1.126.0-arm64-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Silicon.Mac.Pulsar-1.127.0-arm64.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Silicon.Mac.Pulsar-1.127.0-arm64-mac.zip) |  Zip archive  |
 
 **Intel** - For Intel macs
 
 |                                                 Package                                                  |     Type      |
 | :------------------------------------------------------------------------------------------------------: | :-----------: |
-|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Intel.Mac.Pulsar-1.126.0.dmg)   | DMG installer |
-| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Intel.Mac.Pulsar-1.126.0-mac.zip) |  Zip archive  |
+|   [dmg](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Intel.Mac.Pulsar-1.127.0.dmg)   | DMG installer |
+| [zip](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Intel.Mac.Pulsar-1.127.0-mac.zip) |  Zip archive  |
 
 ::::
 
@@ -178,8 +178,8 @@ You can bypass this by clicking "More info" then "Run anyway".
 
 |                                                   Package                                                   |         Type          |
 | :---------------------------------------------------------------------------------------------------------: | :-------------------: |
-| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Windows.Pulsar.Setup.1.126.0.exe)  |       Installer       |
-| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.126.0/Windows.Pulsar-1.126.0-win.zip) | Portable (no install) |
+| [Setup](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Windows.Pulsar.Setup.1.127.0.exe)  |       Installer       |
+| [Portable](https://github.com/pulsar-edit/pulsar/releases/download/v1.127.0/Windows.Pulsar-1.127.0-win.zip) | Portable (no install) |
 
 |                        Package Manager                         |        Command         |
 | :------------------------------------------------------------: | :--------------------: |


### PR DESCRIPTION
A second release for this month, to catch up to a more usual cadence, I guess.

This PR adds the blog post and updates the download links for the website to announce and reflect this new version, respectively.

Update: Also includes blog post and updated links for hotfix v1.127.1. 