### PR TITLE
Make the 'Our Sponsors' section responsive

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -83,6 +83,23 @@ html[data-theme=dark] .custom-container.details th {
   margin-left: auto;
   margin-right: auto;
 }
+
+// make the sponsors section responsive
+@media (max-width: 700px) {
+  .links {
+    display: inline-block;
+    max-width: 100%;
+    max-height: auto;
+    overflow: hidden;
+
+    img{
+      object-fit: contain;
+      max-width: 100%;
+      max-height: auto;
+    } 
+  }
+}
+
 //Website footer section
 
 //Theme adds a sidebar width even on mobile when it doesnt show, this removes it.


### PR DESCRIPTION
Add the css property `overflow:hidden` to the links in our sponsors section. This eliminates its overflowing that leads to displaying an empty giant chunk on the rightmost side of the website homepage when opened on smaller screens.

This is in reference to issue: #300 

Managed to trace the bug to the 'Our Sponsors' section:
![Screenshot From 2025-05-11 15-57-29](https://github.com/user-attachments/assets/25319f60-3e35-4eb1-914b-6b3087d5d268)

The red outline is where the image div is supposed to end, the words clearly overflow out of the div and into the other page contants. I rectified this by using a media query in the `docs/.vuepress/styles/index.scss` that changes display style from flex to block on smaller screens. This enables one to set the `overflow` property to hidden, and it will look like this:

![Screenshot From 2025-05-11 18-06-36](https://github.com/user-attachments/assets/67d7fac9-1e38-4948-8766-9593fb365c2d)

> [!NOTE]
> I used multiple sponsors to see how it will react to future changes, but it will work the same for a single sponsor.
> The yellow outline is the links section and the red outline is a single image section


