### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docs/docs/launch-manual/sections/core-hacking/sections/building-pulsar.md
+++ b/docs/docs/launch-manual/sections/core-hacking/sections/building-pulsar.md
@@ -117,7 +117,7 @@ use.
 ### Building binaries
 
 The following will allow you to build Pulsar as a stand alone binary or
-installer. After running you will find your your built application in
+installer. After running you will find your built application in
 `pulsar/binaries`.
 
 The build script will automatically build for your system's CPU architecture,


### PR DESCRIPTION
In the website documentation [here](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#building-binaries) there was a typo, where `your` was repeated. I eliminated one occurrence of it.

![Screenshot From 2025-05-12 05-32-46](https://github.com/user-attachments/assets/3f0a7149-210e-49fa-b213-cdb56d257bc7)
