### PR TITLE
Remove `v` from version string in json data

### DIFF
--- a/docs/global.json
+++ b/docs/global.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "v1.128.0"
+  "latest_version": "1.128.0"
 }


### PR DESCRIPTION
In our `./docs/global.json` the `latest_version` has `vXXX` while it should be `XXX` because we prepend the `v` later on. This PR removes the `v` from the data to restore download links