### PR TITLE
Add Gentoo to the list of community supported packaged linux installations

### DIFF
--- a/docs/download/download.11tydata.js
+++ b/docs/download/download.11tydata.js
@@ -326,6 +326,10 @@ function data () {
                   "pacstall": {
                     "title": "Pacstall",
                     "url": "https://pacstall.dev/packages/pulsar-deb"
+                  },
+                  "gentoo": {
+                    "title": "Gentoo",
+                    "url": "https://gpo.zugaina.org/Overlays/guru/app-editors/pulsar-bin"
                   }
                 }
               }


### PR DESCRIPTION
As the title says, ads another community supported packaged installation for linux.

Originally authored by @zhuyifei1999, modified by myself to make it usable on the new website.

Closes #213 