### PR TITLE
Make the page-header static at narrow breakpoints

### DIFF
--- a/less/page-header.less
+++ b/less/page-header.less
@@ -105,6 +105,21 @@
   }
 }
 
+// Page header should be static at narrow widths so it doesn't take up half the
+// screen…
+.page-header {
+  position: static !important;
+}
+
+@media (min-width: @bp-larger-than-phablet) {
+  // …but once we have enough room for it not to be so tall, we can afford to
+  // make it sticky.
+  .page-header {
+    position: sticky !important;
+  }
+
+}
+
 @media (min-width: @bp-larger-than-mobile) {
   .page-header .page-header {
     &__items {


### PR DESCRIPTION
This makes it so that, when you're looking at the new homepage in a very narrow viewport (like a phone), the top navigation doesn't go “sticky” and stay in view all the time. Because we have a lot of options in the top nav, they go vertical when the screen is narrow, and the real estate it takes up is quite great.