### PR TITLE
Ensure community menu appears above platform switcher

### DIFF
--- a/less/page-header.less
+++ b/less/page-header.less
@@ -41,7 +41,6 @@
   .page-header__community-links {
     opacity: 1;
     visibility: visible;
-    z-index: 2;
     transform: scale(1);
   }
 }
@@ -150,4 +149,8 @@
       margin-bottom: 0;
     }
   }
+}
+
+.platform-switcher {
+  z-index: unset !important;
 }


### PR DESCRIPTION
We're approaching ridiculousness here, but one more quick fix: the “Community” menu appears _underneath_ the platform switcher on the download page. We can fix this by removing the `z-index` from `.platform-switcher`, since it's already applied to `.page-header`.