### PR TITLE
Add `scoop` as a community supported win package manager

### DIFF
--- a/docs/download/download.11tydata.js
+++ b/docs/download/download.11tydata.js
@@ -367,6 +367,10 @@ function data () {
                   "winget": {
                     "title": "winget",
                     "url": "https://winstall.app/apps/Pulsar-Edit.Pulsar"
+                  },
+                  "scoop": {
+                    "title": "scoop",
+                    "url": "https://scoop.sh/#/apps?q=pulsar&id=b73e2993681c0efcdf8f5eb26582458e106e7d05"
                   }
                 }
               }


### PR DESCRIPTION
As we recently discovered in a bug report, `scoop` is a community supported package manager for Windows.

So while thinking of it, I wanted to make sure to update it here.